### PR TITLE
fix add liquidity page crash

### DIFF
--- a/apps/cave/components/AMM/AddLiquidity/AddLiquidity.tsx
+++ b/apps/cave/components/AMM/AddLiquidity/AddLiquidity.tsx
@@ -64,13 +64,11 @@ function AddLiquidityContent({
     supplyLiquidityDisclosure.onOpen,
   )
 
-  let fixedPair
-  if (pair.data) {
-    fixedPair = pair.data
-  } else if (firstFieldAmount && secondFieldAmount) {
+  let fixedPair = pair.data
+
+  if (firstFieldAmount?.currency && secondFieldAmount?.currency && !pair.data) {
     fixedPair = Pair.createVirtualPair(firstFieldAmount, secondFieldAmount)
   }
-  // const fixedPair = pair.data ?? Pair.createVirtualPair(firstFieldAmount, secondFieldAmount)
 
   const lpData = useLiquidityData({
     pair: fixedPair,


### PR DESCRIPTION
fixes page crash by letting `lpData = par.data`

otherwise it'll obtain data from `createVirtualPair`