### PR TITLE
ce-581: fix (cave/bond): amountIn>balance button message.

### DIFF
--- a/apps/cave/components/Bond/BondBuyCard.tsx
+++ b/apps/cave/components/Bond/BondBuyCard.tsx
@@ -39,7 +39,7 @@ const GasPrice = () => {
     </>
   )
 }
-//aaaa
+
 export function BondBuyCard(props: {
   bondTransaction?: any
   setBondTransaction?: any
@@ -51,7 +51,6 @@ export function BondBuyCard(props: {
   const [bondTransaction, setBondTransaction] = useState()
 
   const [settings, setSetting] = useBondSettings()
-  const userBalance = balance.data?.toFixed()
   const [amountIn, setAmountIn] = useState<CurrencyAmount<Currency>>(toAmount('0', DAI[networkId]))
   // const [amountIn, setAmountIn] = useState<number>(0)
 
@@ -156,13 +155,12 @@ export function BondBuyCard(props: {
           amount: amountIn.numerator,
           spender: BOND_ADDRESS[networkId],
         }}
-        isDisabled={
-          +amountIn.numerator.toString() === 0 ||
-          +userBalance < +amountIn.numerator.toString() / 10 ** 18
-        }
+        isDisabled={amountIn.equalTo(0) || balance.data?.lessThan(amountIn)}
         onClick={confirmModal.onOpen}
       >
-        {+userBalance < +amountIn ? 'Insufficient Funds' : 'Bond'}
+        {balance.data?.lessThan(amountIn.numerator)
+          ? `Insufficient ${amountIn.currency.symbol}`
+          : 'Bond'}
       </ApproveButton>
 
       <ConfirmBondModal


### PR DESCRIPTION
the bond button will now read `Insufficient {TOKEN}` when `amount in > balance`. implements core to better compare `Currency` values without transforming them into js numbers

![bond_button_ux](https://user-images.githubusercontent.com/96499579/172524452-1041933e-94d8-43f4-91bb-f391896a914f.gif)

