### PR TITLE
ce-612: add a button to expand trade details component

### DIFF
--- a/apps/cave/pages/gemswap.tsx
+++ b/apps/cave/pages/gemswap.tsx
@@ -166,7 +166,7 @@ export function SwapPage({ currencies: serverPropsCurrencies }) {
                   px={3}
                   py={2}
                   my={1}
-                  shadow={isDetailsOpen ? 'Down Small' : 'Up Small'}
+                  shadow={isDetailsOpen ? 'Down Big' : 'Up Small'}
                   rounded="3xl"
                 >
                   <ExpandArrowIcon


### PR DESCRIPTION
![ce-612-demo2](https://user-images.githubusercontent.com/96499579/173504716-ce887531-0618-4ef4-9a32-ffe2b8ac99d6.gif)

on gemswap, add a button between gwei read out and settings when we have trade details