### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@ Explain how to test functionality on the UI, if applicable.
 
 ## Checklist
 - [ ] PR is named correctly
-  - example: `CE-123: description`, `CE123 description`
+  - example: `CE-123: description`, `CE123 description`, `description`


### PR DESCRIPTION
## Description
Adds a PR template to make PRs a little more obvious. Should help when there are no assigned tickets to the PR.

## Steps to UI Test
None.

## Checklist
- [x] PR is named correctly
