### PR TITLE
fix transaction explorer links

### DIFF
--- a/apps/cave/lib/getTransactionExplorer.ts
+++ b/apps/cave/lib/getTransactionExplorer.ts
@@ -1,8 +1,12 @@
-import { ChainId, CHAIN_NAME } from '@concave/core'
+import { ChainId } from '@concave/core'
 import { etherscanBlockExplorers } from 'wagmi'
 
 export const getTxExplorer = (hash: string, chainId: ChainId) => {
-  // TODO: needs further investigation, but the ethers Transaction object sometimes don't have a chainId or it is 0
-  const _chainId = chainId || ChainId.ETHEREUM
-  return etherscanBlockExplorers[CHAIN_NAME[_chainId]]?.url + `/tx/${hash}`
+  const explorerUrl =
+    {
+      [ChainId.ETHEREUM]: etherscanBlockExplorers.mainnet.url,
+      [ChainId.RINKEBY]: etherscanBlockExplorers.rinkeby.url,
+    }[chainId] || etherscanBlockExplorers.mainnet.url
+
+  return `${explorerUrl}/tx/${hash}`
 }


### PR DESCRIPTION
## Steps to UI Test

go to your recent txs screen on *mainnet* and click a any tx
you would expect to go to the explorer but end up in a 404 concave page, ONLY ON MAINNET

if you don't have/wanna do txs on mainnet to test this copy paste this code into the console

```js
const address = JSON.parse(JSON.parse(localStorage.getItem('wagmi.store'))).state.data.account

const tx = {
  chainId: 1,
  from: address,
  hash: '0xc9ad542c551751a3bfd42e9489e78d9edec166fada4e1ca1737849c91e1cb08a',
  meta: { type: 'approve', tokenSymbol: 'CNV' },
  status: 'success',
  timestamp: 1657586170032,
}

localStorage.setItem(`transactions ${address} 1`, JSON.stringify([tx]))

```

***NOTE: IF YOU HAVE A MAINNET HISTORY AND DON'T WANNA LOSE IT DON'T PASTE THIS INTO YOUR CONSOLE***
AS THE LOCALSTORAGE CHANGES WILL BE IRREVERSIBLE
only affects the recent transactions screen
