### PR TITLE
Load analytics on a web worker

### DIFF
--- a/apps/cave/next.config.mjs
+++ b/apps/cave/next.config.mjs
@@ -11,6 +11,9 @@ const nextConfig = {
   images: {
     formats: ['image/avif', 'image/webp'],
   },
+  experimental: {
+    nextScriptWorkers: true,
+  },
   async rewrites() {
     return [
       { source: '/', destination: '/gemswap' },

--- a/apps/cave/package.json
+++ b/apps/cave/package.json
@@ -53,6 +53,7 @@
     "wagmi": "^0.5.9"
   },
   "devDependencies": {
+    "@builder.io/partytown": "^0.6.2",
     "@chakra-ui/cli": "^2.0.0",
     "@graphql-codegen/cli": "^2.7.0",
     "@graphql-codegen/introspection": "^2.1.1",

--- a/apps/cave/pages/_document.tsx
+++ b/apps/cave/pages/_document.tsx
@@ -1,6 +1,28 @@
 import { ColorModeScript, ThemeFontsPreload } from '@concave/ui'
 import { GA_TRACKING_ID } from 'lib/env.conf'
 import NextDocument, { Head, Html, Main, NextScript } from 'next/document'
+import Script from 'next/script'
+
+const TrackingScripts = () => (
+  <>
+    {/* Global Site Tag (gtag.js) - Google Analytics */}
+    {/* consider using https://usefathom.com/ to replace Google  */}
+    <Script
+      src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+      strategy="worker"
+    />
+    <Script id="gtag" strategy="lazyOnload">
+      {`
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${GA_TRACKING_ID}', {
+          page_path: window.location.pathname,
+        });
+      `}
+    </Script>
+  </>
+)
 
 export default class Document extends NextDocument {
   render() {
@@ -8,27 +30,12 @@ export default class Document extends NextDocument {
       <Html lang="en">
         <Head>
           <ThemeFontsPreload />
+          <TrackingScripts />
         </Head>
         <body>
           <ColorModeScript />
           <Main />
           <NextScript />
-          {/* Global Site Tag (gtag.js) - Google Analytics */}
-          {/* consider using https://usefathom.com/ to replace Google  */}
-          <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
-          <script
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{
-              __html: `
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${GA_TRACKING_ID}', {
-              page_path: window.location.pathname,
-            });
-          `,
-            }}
-          />
         </body>
       </Html>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1081,6 +1081,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@builder.io/partytown@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.6.2.tgz#3437fb5a0fcbdd36f239bbde05ff31c60948386e"
+  integrity sha512-2wSTB7v3176Mzfu+gTGm+I7MAALeOpvATQ5qf+NUMLfeuvVEX/eWxcJPrrIy7UcoQyT3Mm6Tsb2sfBqJy4R4EQ==
+
 "@chakra-ui/accordion@2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-2.0.3.tgz#4f9db1459698fd91d68f913fe7f6d1687cefabbd"


### PR DESCRIPTION
## Description

Improve the performance by keeping the main tread for our app, and loading tracking scripts on a web worker
check: [next <Script /> docs](https://nextjs.org/docs/basic-features/script#off-loading-scripts-to-a-web-worker-experimental) and [partytown](https://partytown.builder.io/nextjs)

as a further improvement I'd suggest replacing google analytics with [plausible.io](https://plausible.io/) or [fanthom](https://usefathom.com/) as they are better aligned with crypto privacy focused culture

## Steps to UI Test

we have to test if it's still tracking, I don't have access to analytics so this pr was not tested at all