### PR TITLE
CE-705: Staking percent fix

### DIFF
--- a/apps/cave/components/LiquidStaking/StakeCard.tsx
+++ b/apps/cave/components/LiquidStaking/StakeCard.tsx
@@ -102,12 +102,16 @@ const LoadBar = ({ percent, currentlyStaked, loading, stakingCap, variant }: Loa
       my={2}
       p={1}
     >
-      <Flex
-        width={`${percent.toSignificant(3)}%`}
-        height="full"
-        apply={'background.metalBrighter'}
-        rounded="full"
-      />
+      <Flex w="full" height={'full'} overflow="hidden" rounded={'inherit'}>
+        <Flex
+          transform={`translateX(-${100 - +percent.toSignificant(3)}%)`}
+          width={`full`}
+          height="full"
+          apply={'background.metalBrighter'}
+          rounded="full"
+        />
+      </Flex>
+
       <Flex
         position={'absolute'}
         mx={-1}


### PR DESCRIPTION
## Description

This pull request will fix the loadbar percent calculation on stake card component and modal,
and will fix the wrong width bar when percent is tiny.

## Steps to UI Test

Go to current page: https://alpha.concave.lol/liquid-staking
Got to the last deploy of this branch: https://concave-frontend-78ln56f8q-concavefi.vercel.app/liquid-staking
then compare the stake card components

## Checklist

- [x] PR is named correctly
