### PR TITLE
CEB-115-usdc-shows-listing-price-as-0

### DIFF
--- a/apps/cave/components/StakingPositions/LockPosition/MarketLockInfo/ConfirmSignature.tsx
+++ b/apps/cave/components/StakingPositions/LockPosition/MarketLockInfo/ConfirmSignature.tsx
@@ -43,7 +43,12 @@ export const ConfirmSignature = ({
       <Box p={4} shadow={`Down Medium`} w={'full'} borderRadius={'3xl'}>
         <Info label="Item:" value={`#` + market.tokenId.toString()}></Info>
         <Info label="Current price:" value={formatFixed(staking.currentValue) + ` CNV`}></Info>
-        <Info label="Listed price:" value={formatFixed(market.startPrice) + ` CNV`}></Info>
+        <Info
+          label="Listed price:"
+          value={
+            formatFixed(market.startPrice, { ...market.currency }) + ` ${market.currency.symbol}`
+          }
+        ></Info>
         <Info
           label="Discount:"
           isLoading={discount.isLoading}


### PR DESCRIPTION
## Description

Fix NFT Listing when using USDC, listed price shows 0 in the modal. Confirmed that it shows as expected in my list of staked positions.

## Steps to UI Test

- Open your positions
- List to sell with USDC
- List
