### PR TITLE
CE-584: Warning + Color Switch on Negative Bond event

### DIFF
--- a/apps/cave/components/Bond/BondBuyCard.tsx
+++ b/apps/cave/components/Bond/BondBuyCard.tsx
@@ -24,6 +24,7 @@ import { numberMask } from 'utils/numberMask'
 export function BondBuyCard(props: {
   updateBondPositions?: VoidFunction
   setRedeemButtonDisabled?: (b: boolean) => void
+  roi?: number
 }) {
   const confirmModal = useDisclosure()
   const rejectDisclosure = useDisclosure()
@@ -148,6 +149,7 @@ export function BondBuyCard(props: {
         minimumAmountOut={(+amountOut - (+settings.slippageTolerance / 100) * +amountOut).toFixed(
           3,
         )}
+        roi={props.roi}
         slippage={settings.slippageTolerance?.toString()}
       />
       <WaitingConfirmationDialog

--- a/apps/cave/components/Bond/BondInfo.tsx
+++ b/apps/cave/components/Bond/BondInfo.tsx
@@ -2,6 +2,7 @@ import { keyframes } from '@chakra-ui/system'
 import { SpinIcon } from '@concave/icons'
 import { Box, Card, Flex, Image, Text } from '@concave/ui'
 import { utils } from 'ethers'
+import { getRoiWarnColor } from 'utils/getRoiWarnColor'
 const spin = keyframes({
   '0%': { transform: 'rotate(0deg)' },
   '100%': { transform: 'rotate(360deg)' },
@@ -33,7 +34,15 @@ export const BondInfo = ({ asset, roi, vestingTerm, icon }) => {
         <InfoItem value={asset.toUpperCase()} label="Asset" />
       </Flex>
       <Box w="1px" mx={0} my={-4} bg="stroke.primary" />
-      <InfoItem value={roi} label="ROI" flexGrow={1} pl={3} pr={3} flexBasis="25%" />
+      <InfoItem
+        value={+roi.toFixed(2) + '%'}
+        label="ROI"
+        flexGrow={1}
+        pl={3}
+        pr={3}
+        flexBasis="25%"
+        color={getRoiWarnColor(+roi)}
+      />
       <Box w="1px" mx={0} my={-4} bg="stroke.primary" />
       <InfoItem value={vestingTerm} label="Vesting Term" px={5} flexBasis="35%" />
     </Card>

--- a/apps/cave/components/Bond/ConfirmBond.tsx
+++ b/apps/cave/components/Bond/ConfirmBond.tsx
@@ -94,8 +94,13 @@ export const ConfirmBondModal = ({
   const [agree, setAgree] = useState(false)
   const negativeRoi = roi < 0
 
+  const onCloseModal = () => {
+    setAgree(false)
+    onClose()
+  }
+
   return (
-    <Modal bluryOverlay={true} title="Confirm Bond" isOpen={isOpen} onClose={onClose}>
+    <Modal bluryOverlay={true} title="Confirm Bond" isOpen={isOpen} onClose={onCloseModal}>
       <div>
         <TokenInfo
           currency={currencyIn}
@@ -142,7 +147,7 @@ export const ConfirmBondModal = ({
       )}
       {negativeRoi && (
         <Flex px={2} gap={4} mt={3} mb={1}>
-          <Checkbox defaultChecked={false} onChange={(v) => setAgree(!agree)} />
+          <Checkbox defaultChecked={agree} onChange={(v) => setAgree(!agree)} />
           <Text color={'text.low'}>
             I understand that bond roi is{' '}
             <Text as={'strong'} color="red.300">

--- a/apps/cave/components/Bond/ConfirmBond.tsx
+++ b/apps/cave/components/Bond/ConfirmBond.tsx
@@ -142,7 +142,7 @@ export const ConfirmBondModal = ({
       )}
       {negativeRoi && (
         <Flex px={2} gap={4} mt={3} mb={1}>
-          <Checkbox onChange={(v) => setAgree(!agree)} />
+          <Checkbox defaultChecked={false} onChange={(v) => setAgree(!agree)} />
           <Text color={'text.low'}>
             I understand that bond roi is{' '}
             <Text as={'strong'} color="red.300">

--- a/apps/cave/components/Bond/ConfirmBond.tsx
+++ b/apps/cave/components/Bond/ConfirmBond.tsx
@@ -1,8 +1,19 @@
 import { Currency } from '@concave/core'
-import { ExpandArrowIcon } from '@concave/icons'
-import { Box, Button, Flex, HStack, Modal, NumericInput, StackDivider, Text } from '@concave/ui'
+import { ExpandArrowIcon, WarningTwoIcon } from '@concave/icons'
+import {
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  HStack,
+  Modal,
+  NumericInput,
+  StackDivider,
+  Text,
+} from '@concave/ui'
 import { CurrencyIcon } from 'components/CurrencyIcon'
 import { UseTransaction } from 'hooks/TransactionsRegistry/useTransaction'
+import { useState } from 'react'
 
 const TokenInfo = ({
   currency,
@@ -64,6 +75,7 @@ export const ConfirmBondModal = ({
   minimumAmountOut,
   slippage,
   transaction,
+  roi,
 }: {
   transaction: UseTransaction
   currencyIn: Currency
@@ -77,7 +89,11 @@ export const ConfirmBondModal = ({
   bondPrice: string
   minimumAmountOut: string
   slippage: string
+  roi?: number
 }) => {
+  const [agree, setAgree] = useState(false)
+  const negativeRoi = roi < 0
+
   return (
     <Modal bluryOverlay={true} title="Confirm Bond" isOpen={isOpen} onClose={onClose}>
       <div>
@@ -112,11 +128,35 @@ export const ConfirmBondModal = ({
         </Text>
       </Flex>
 
+      {negativeRoi && (
+        <Flex color={'yellow.100'} direction="column" align={'center'}>
+          <WarningTwoIcon boxSize={'25px'} color="yellow.100" />
+          <Text textAlign={'center'}>
+            Current bond roi Is{' '}
+            <Text color={'red.300'} as="strong">
+              negative
+            </Text>
+            , <br /> are you sure you want to bond anyway? <br /> You may lose money.
+          </Text>
+        </Flex>
+      )}
+      {negativeRoi && (
+        <Flex px={2} gap={4} mt={3} mb={1}>
+          <Checkbox onChange={(v) => setAgree(!agree)} />
+          <Text color={'text.low'}>
+            I understand that bond roi is{' '}
+            <Text as={'strong'} color="red.300">
+              {roi.toFixed(2) || '0'}%
+            </Text>
+          </Text>
+        </Flex>
+      )}
+
       <Button
         variant="primary"
         size="large"
         onClick={transaction.sendTx}
-        disabled={transaction.isWaitingForConfirmation}
+        disabled={transaction.isWaitingForConfirmation || (roi < 0 && !agree)}
         w="full"
       >
         {transaction.isWaitingForConfirmation ? 'Confirm in wallet' : 'Confirm bond'}

--- a/apps/cave/components/SideBar/PageNav.tsx
+++ b/apps/cave/components/SideBar/PageNav.tsx
@@ -6,6 +6,7 @@ import { useCurrentSupportedNetworkId } from 'hooks/useCurrentSupportedNetworkId
 import Router from 'next/router'
 import { useQuery } from 'react-query'
 import getROI from 'utils/getROI'
+import { getRoiWarnColor } from 'utils/getRoiWarnColor'
 import { useAccount } from 'wagmi'
 
 const NavButton = (props: ButtonLinkProps) => {
@@ -67,22 +68,29 @@ const NotInteractableImage = ({ src, ...props }) => (
 const BondROI = () => {
   const currentSupportedNetworkId = useCurrentSupportedNetworkId()
   const cnvPrice = useCNVPrice()
-  const roi = useQuery(
+  const { isError, isFetching, isIdle, data } = useQuery(
     ['bondROI', currentSupportedNetworkId, cnvPrice.price],
     async () => {
       const cnvMarketPrice = cnvPrice?.price?.toSignificant(8)
       const bondSpotPrice = await getBondSpotPrice(currentSupportedNetworkId)
-      return getROI(cnvMarketPrice, bondSpotPrice)
+      return {
+        amount: (1 - +bondSpotPrice / +cnvMarketPrice) * 100,
+        formatted: getROI(cnvMarketPrice, bondSpotPrice),
+      }
     },
     { enabled: cnvPrice.isSuccess && !!currentSupportedNetworkId, refetchInterval: 17000 },
   )
-
+  const { amount, formatted } = data || {}
   return (
     <Flex justify="center" align="center" textColor="text.low" p="9px" m="-3px" mt="0">
       <Text fontSize="xs" fontWeight="bold" mr={1}>
-        {`CNV-DAI ${roi.data || ''}`} {roi.isError ? 'error' : ''}
+        {`CNV-DAI `}
+        <Text as={'span'} color={getRoiWarnColor(amount)} fontSize="xs" fontWeight="bold">
+          {formatted}
+        </Text>
+        {isError ? 'error' : ''}
       </Text>
-      {(roi.isFetching || roi.isIdle) && <Spinner size={'xs'} />}
+      {(isFetching || isIdle) && <Spinner size={'xs'} />}
     </Flex>
   )
 }

--- a/apps/cave/pages/smart-bonding.tsx
+++ b/apps/cave/pages/smart-bonding.tsx
@@ -34,7 +34,6 @@ import { useGet_Accrualbondv1_Last10_SoldQuery } from 'graphql/generated/graphql
 import { useTransactionRegistry } from 'hooks/TransactionsRegistry'
 import { useCNVPrice } from 'hooks/useCNVPrice'
 import { useEffect, useState } from 'react'
-import getROI from 'utils/getROI'
 const spin = keyframes({
   '0%': { transform: 'rotate(0deg)' },
   '100%': { transform: 'rotate(360deg)' },
@@ -211,7 +210,7 @@ export function Bond() {
                         <BondInfo
                           asset="CNV"
                           icon="/assets/tokens/cnv.svg"
-                          roi={getROI(cnvPrice.price?.toSignificant(8), bondSpotPrice)}
+                          roi={(1 - +bondSpotPrice / +cnvPrice.price?.toSignificant(8)) * 100}
                           vestingTerm={`${termLength} Days`}
                         />
                       </Collapse>

--- a/apps/cave/pages/smart-bonding.tsx
+++ b/apps/cave/pages/smart-bonding.tsx
@@ -152,6 +152,7 @@ export function Bond() {
         setButtonDisabled(false)
       })
   }
+  const roi = (1 - +bondSpotPrice / +cnvPrice.price?.toSignificant(8)) * 100
 
   return (
     <Container maxW="container.lg" p={'4px'}>
@@ -210,7 +211,7 @@ export function Bond() {
                         <BondInfo
                           asset="CNV"
                           icon="/assets/tokens/cnv.svg"
-                          roi={(1 - +bondSpotPrice / +cnvPrice.price?.toSignificant(8)) * 100}
+                          roi={roi}
                           vestingTerm={`${termLength} Days`}
                         />
                       </Collapse>
@@ -242,6 +243,7 @@ export function Bond() {
             </Card>
           </Box>
           <BondBuyCard
+            roi={roi}
             updateBondPositions={updateBondPositions}
             setRedeemButtonDisabled={setButtonDisabled}
           />

--- a/apps/cave/utils/getRoiWarnColor.ts
+++ b/apps/cave/utils/getRoiWarnColor.ts
@@ -1,0 +1,5 @@
+export const getRoiWarnColor = (amount: number) => {
+  if (amount < 0) return 'red.300'
+  else if (amount >= 0 && amount < 45) return 'none'
+  else return 'green.300'
+}


### PR DESCRIPTION
## Description

This pr will add warn color when bond roi is negative, and will make warn on confirmation modal, so that user has to agree that bond roi is negative first to be able to make a bond

## Confirmation modal
<img width="405" alt="image" src="https://user-images.githubusercontent.com/62969153/192278051-edf6ff95-393a-421e-8e83-daec65dee55f.png">


This

## Checklist

- [x] PR is named correctly
- [x] Warn color on side bar
- [x] warn color on bond page
- [x] warn + user agreement on confirmation modal
