### PR TITLE
CE-905: refactor redeem and treasury dividend card

### DIFF
--- a/apps/cave/components/Transparency/DividendsCard.tsx
+++ b/apps/cave/components/Transparency/DividendsCard.tsx
@@ -1,57 +1,50 @@
 import { Card, Flex, Text } from '@concave/ui'
-interface DividendsCardProps {
-  onChange: () => void
-}
 
-export default function DividendsCard({ width }: { width: string }) {
+export default function DividendsCard() {
   return (
     <Card
       direction={{ base: 'column', lg: 'row' }}
       align="center"
-      w={width}
+      w={'100%'}
       variant="secondary"
-      height={{ base: '260px', lg: '179px' }}
-      py={{ base: 2, lg: 0 }}
-      px={6}
+      height={'auto'}
+      p={6}
+      justifyContent={'center'}
+      gap={{ base: 4, xl: 0 }}
     >
-      <Flex
-        direction={{ base: 'column', xl: 'row' }}
-        align="center"
-        mx={'auto'}
-        gap={{ base: 0, xl: 0 }}
-      >
-        <Text fontSize={'4xl'} fontWeight="700">
-          Dividends
-        </Text>
+      <Text textAlign={'center'} w={{ base: '100%', lg: '33%' }} fontSize={'3xl'} fontWeight={700}>
+        Dividends
+      </Text>
+      <Flex justifyContent={'center'} w={{ base: '100%', lg: '33%' }}>
         <Text
-          textAlign={{ base: 'center', xl: 'justify' }}
+          textAlign={'center'}
           fontWeight={700}
           textColor={'text.low'}
           fontSize="14px"
-          maxW={'350px'}
-          px={{ base: 12, md: 0, xl: 6 }}
+          w={{ base: '70%', lg: '90%' }}
         >
           Dividends are distributed on a quarterly basis to the holders. You may redeem these
           dividends upon the distribution date on the Your Stake Position page.
         </Text>
       </Flex>
-      <Card
-        width={'250px'}
-        height="105px"
-        rounded={'2xl'}
-        direction="column"
-        justify={'center'}
-        align="center"
-        fontWeight="700"
-        my={'auto'}
-        mx="auto"
-        shadow={'up'}
-      >
-        <Text fontSize={'2xl'}>Coming Soon</Text>
-        <Text textColor={'text.low'} fontSize="14px">
-          Distribution date TBD
-        </Text>
-      </Card>
+      <Flex justifyContent={'center'} w={{ base: '100%', lg: '33%' }}>
+        <Card
+          width={'250px'}
+          height="105px"
+          rounded={'2xl'}
+          direction="column"
+          justify={'center'}
+          align="center"
+          fontWeight={700}
+          my={'auto'}
+          shadow={'up'}
+        >
+          <Text fontSize={'2xl'}>Coming Soon</Text>
+          <Text textColor={'text.low'} fontSize="14px">
+            Distribution date TBD
+          </Text>
+        </Card>
+      </Flex>
     </Card>
   )
 }

--- a/apps/cave/components/Transparency/DividendsCard.tsx
+++ b/apps/cave/components/Transparency/DividendsCard.tsx
@@ -15,7 +15,7 @@ export default function DividendsCard() {
       <Text textAlign={'center'} w={{ base: '100%', lg: '33%' }} fontSize={'3xl'} fontWeight={700}>
         Dividends
       </Text>
-      <Flex justifyContent={'center'} w={{ base: '100%', lg: '33%' }}>
+      <Flex justifyContent={'center'} w={{ base: '100%', lg: '33%' }} mb={{ base: 3, lg: 0 }}>
         <Text
           textAlign={'center'}
           fontWeight={700}

--- a/apps/cave/components/Transparency/TreasuryRedeemCard.tsx
+++ b/apps/cave/components/Transparency/TreasuryRedeemCard.tsx
@@ -30,12 +30,22 @@ export const TreasuryRedeemCard = () => {
       <Text w={{ base: '100%', lg: '33%' }} fontSize={'3xl'} fontWeight={700}>
         Redeem CNV
       </Text>
-      <Flex justifyContent={'center'} w={{ base: '100%', lg: '66%' }} direction={'column'}>
+      <Flex
+        justifyContent={'center'}
+        w={{ base: '100%', lg: '66%' }}
+        direction={'column'}
+        gap={{ base: 2, lg: 0 }}
+      >
         <Text color="text.low" textAlign={'center'} fontWeight="bold">
           Redeem your tokens for CNV below
         </Text>
 
-        <Flex direction={{ base: 'column', md: 'row', lg: 'row' }} w="full" gap={3} py={3}>
+        <Flex
+          direction={{ base: 'column', md: 'row', lg: 'row' }}
+          w="full"
+          gap={{ base: 6, lg: 3 }}
+          py={3}
+        >
           <VestedTokenButton title="aCNV" VestedTokenDialog={ACNVRedemptionDialog} />
           <VestedTokenButton title="pCNV" VestedTokenDialog={PCNVRedemptionDialog} />
           <VestedTokenButton title="bbtCNV" VestedTokenDialog={BBTCNVRedemptionDialog} />

--- a/apps/cave/components/Transparency/TreasuryRedeemCard.tsx
+++ b/apps/cave/components/Transparency/TreasuryRedeemCard.tsx
@@ -8,7 +8,7 @@ import { ACNVRedemptionDialog } from './VestedTokensDialogs/ACNVRedemptionDialog
 import { BBTCNVRedemptionDialog } from './VestedTokensDialogs/BBTCNVRedemptionDialog'
 import { PCNVRedemptionDialog } from './VestedTokensDialogs/PCNVRedemptionDialog'
 
-export const TreasuryRedeemCard = ({ width }: { width: string }) => {
+export const TreasuryRedeemCard = () => {
   const chaindId = useCurrentSupportedNetworkId()
   const { addingToWallet }: injectedTokenResponse = useAddTokenToWallet({
     tokenAddress: CNV[chaindId].address,
@@ -19,16 +19,18 @@ export const TreasuryRedeemCard = ({ width }: { width: string }) => {
   return (
     <Card
       variant="secondary"
-      w={{ base: width }}
-      h={{ base: '315px', md: '200px', xl: '150px' }}
-      px={{ base: 0, md: 10, xl: '6' }}
-      py={6}
+      w={'100%'}
+      h={'auto'}
+      p={6}
       direction={{ base: 'column', xl: 'row' }}
+      align="center"
+      justifyContent={'center'}
+      gap={{ base: 4, xl: 0 }}
     >
-      <Text my={'auto'} fontSize={'3xl'} fontWeight="bold">
+      <Text w={{ base: '100%', lg: '33%' }} fontSize={'3xl'} fontWeight={700}>
         Redeem CNV
       </Text>
-      <Flex w={{ base: 'full', xl: '75%' }} px={6} direction={'column'} mx="auto" my={'auto'}>
+      <Flex justifyContent={'center'} w={{ base: '100%', lg: '66%' }} direction={'column'}>
         <Text color="text.low" textAlign={'center'} fontWeight="bold">
           Redeem your tokens for CNV below
         </Text>

--- a/apps/cave/pages/transparency.tsx
+++ b/apps/cave/pages/transparency.tsx
@@ -6,7 +6,6 @@ import { TreasuryRedeemCard } from 'components/Transparency/TreasuryRedeemCard'
 import { TransparencyDiagram as TransparencyDiagramComponent } from 'components/TransparencyDiagram/TransparencyDiagram'
 
 const TransparencyDiagram = () => {
-  const narrow = '60%'
   return (
     <Flex align={'center'} w={'100%'} h={'100%'} gap={4} textAlign="center" direction="column">
       <>
@@ -23,8 +22,8 @@ const TransparencyDiagram = () => {
         <TransparencyDiagramComponent />
         <Flex w={'100%'} direction={'column'} gap={6} alignItems={'center'}>
           <TransparencyCharts />
-          <DividendsCard width={narrow} />
-          <TreasuryRedeemCard width={narrow} />
+          <DividendsCard />
+          <TreasuryRedeemCard />
         </Flex>
       </>
     </Flex>


### PR DESCRIPTION
## Description

Makes it so the redeem card and treasury card have proper width. Redeem card also has more spacing between the token buttons

## Steps to UI Test

Check deployment's transparency dashboard on desktop and mobile

## Checklist

- [x] PR is named correctly
  - example: `CE-123: description`, `CE123 description`, `description`
