### PR TITLE
ce-939 update locked-cnv endpoint, data schema

### DIFF
--- a/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
@@ -5,8 +5,8 @@ import { ChartCard } from './ChartCard'
 import { fetchData } from './fetchData'
 
 type AmountCNVLockedData = {
-  ConcaveTokenTotalSupply: number
-  sumAmountLocked: number
+  ratioSupply: number
+  ratio: number
   ratioStaked: number
 }
 
@@ -16,7 +16,7 @@ export function LockedCNVChart({ width, fontSize }: { width: string; fontSize: s
   const [dataLoaded, setDataLoaded] = useState(false)
 
   useEffect(() => {
-    fetchData('locked')
+    fetchData('ratio', 'https://cnv-data.concave.lol/api')
       .then((data: AmountCNVLockedData) => setData(data))
       .catch((error: Error) => setError(error.message))
       .finally(() => setDataLoaded(true))
@@ -34,12 +34,12 @@ export function LockedCNVChart({ width, fontSize }: { width: string; fontSize: s
       {dataLoaded && !error && (
         <>
           <Text color={'text.low'} lineHeight={'100%'}>
-            {numberWithCommas(data.sumAmountLocked.toFixed(4))}
+            {numberWithCommas(data.ratioStaked.toFixed(4))}
             {' / '}
-            {numberWithCommas(data.ConcaveTokenTotalSupply.toFixed(4))} CNV
+            {numberWithCommas(data.ratioSupply.toFixed(4))} CNV
           </Text>
           <Text lineHeight={'100%'} fontSize={fontSize}>
-            {(data.ratioStaked * 100).toFixed(2)}%
+            {(data.ratio * 100).toFixed(2)}%
           </Text>
           <Text fontSize={'large'}>CNV locked in lsdCNV</Text>
         </>


### PR DESCRIPTION
## Description

Updates the endpoint for CNV in lsdCNV from `cnv-charts/api/locked` to `cnv-data/api/ratio`

## Steps to UI Test

check here: https://concave-frontend-hnuzmul2r-concavefi.vercel.app/transparency 

## Checklist

- [x] PR is named correctly
  - example: `CE-123: description`, `CE123 description`, `description`
