### PR TITLE
Ce 965 transparency refetch

### DIFF
--- a/apps/cave/components/LiquidStaking/hooks/useLiquidValues.ts
+++ b/apps/cave/components/LiquidStaking/hooks/useLiquidValues.ts
@@ -3,22 +3,22 @@ import { BigNumber } from 'ethers'
 import { concaveProvider } from 'lib/providers'
 import { useQuery } from 'react-query'
 
-export const useLiquidValues = (chainId: number, poolId: number) => {
-  const { data, isLoading } = useQuery(['LiquidValues', chainId, poolId], async () => {
-    const stakingV1Contract = new StakingV1Contract(concaveProvider(chainId))
-    const contractReads = await Promise.all([
-      stakingV1Contract.pools(poolId),
-      stakingV1Contract.viewStakingCap(poolId).catch(() => {
-        return BigNumber.from(poolId)
-      }),
-    ])
+export const useLiquidValues = (chainId: number, poolId: number) =>
+  useQuery(['LiquidValues', chainId, poolId], async () => liquidityValues(chainId, poolId))
 
-    const stakingV1Pools = contractReads[0]
-    const stakingV1Cap = contractReads[1]
-    return {
-      stakingV1Pools,
-      stakingV1Cap,
-    }
-  })
-  return { data, isLoading }
+export const liquidityValues = async (chainId: number, poolId: number) => {
+  const stakingV1Contract = new StakingV1Contract(concaveProvider(chainId))
+  const contractReads = await Promise.all([
+    stakingV1Contract.pools(poolId),
+    stakingV1Contract.viewStakingCap(poolId).catch(() => {
+      return BigNumber.from(poolId)
+    }),
+  ])
+
+  const stakingV1Pools = contractReads[0]
+  const stakingV1Cap = contractReads[1]
+  return {
+    stakingV1Pools,
+    stakingV1Cap,
+  }
 }

--- a/apps/cave/components/Transparency/Charts/ACNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/ACNVChart.tsx
@@ -1,10 +1,9 @@
 import { Text } from '@concave/ui'
-import { useEffect, useState } from 'react'
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import { ChartCard } from './ChartCard'
 import { ChartTooltip } from './ChartTooltip'
-import { fetchData } from './fetchData'
 import { CHART_COLORS } from './style'
+import { useFetchData } from './useFetchData'
 
 type ACNVChartData = {
   aCNVRedeemed: number
@@ -13,35 +12,28 @@ type ACNVChartData = {
 }
 
 export function ACNVChart({ fontSize }: { fontSize: string }) {
-  const [data, setData] = useState<undefined | ACNVChartData[]>()
-  const [error, setError] = useState<undefined | string>()
-  const [dataLoaded, setDataLoaded] = useState(false)
-
-  useEffect(() => {
-    fetchData('acnv-redeemed')
-      .then((data: ACNVChartData) => setData([data]))
-      .catch((error: Error) => setError(error.message))
-      .finally(() => setDataLoaded(true))
-  }, [])
-
+  const acnvData = useFetchData<ACNVChartData>('acnv-redeemed')
+  const dataLoaded = !acnvData.isLoading
+  const data = acnvData.data
+  const error = acnvData.error
   return (
-    <ChartCard dataLoaded={dataLoaded} chartTitle="aCNV redeem counter">
-      {dataLoaded && error && <Text>{error}</Text>}
+    <ChartCard {...acnvData} chartTitle="aCNV redeem counter">
+      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
       {dataLoaded && !error && (
         <>
           <Text color={'text.low'} lineHeight={'100%'}>
-            {Math.ceil(data[0].aCNVRedeemed).toLocaleString()}
+            {Math.ceil(data.aCNVRedeemed).toLocaleString()}
             {' / '}
-            {Math.ceil(data[0].TOTAL_ACNV).toLocaleString()} aCNV redeemed
+            {Math.ceil(data.TOTAL_ACNV).toLocaleString()} aCNV redeemed
           </Text>
           <Text lineHeight={'100%'} fontSize={fontSize} display={'flex'} justifyContent={'center'}>
-            {data[0].aCNVRedeemedPercent.toFixed(2)}%
+            {data.aCNVRedeemedPercent.toFixed(2)}%
           </Text>
           <Text fontSize={'large'}>aCNV redeemed</Text>
           <ResponsiveContainer width="100%" height="30%">
             <BarChart
               layout="vertical"
-              data={data}
+              data={[data]}
               width={500}
               height={150}
               margin={{
@@ -56,8 +48,8 @@ export function ACNVChart({ fontSize }: { fontSize: string }) {
               <XAxis
                 type="number"
                 dataKey="TOTAL_ACNV"
-                ticks={[0, Math.ceil(data[0].TOTAL_ACNV) / 2, Math.ceil(data[0].TOTAL_ACNV)]}
-                domain={[0, Math.ceil(data[0].TOTAL_ACNV)]}
+                ticks={[0, Math.ceil(data.TOTAL_ACNV) / 2, Math.ceil(data.TOTAL_ACNV)]}
+                domain={[0, Math.ceil(data.TOTAL_ACNV)]}
                 tickFormatter={(v) => v.toLocaleString()}
                 tickLine={{ stroke: CHART_COLORS.TextLow }}
                 axisLine={{ stroke: CHART_COLORS.TextLow }}

--- a/apps/cave/components/Transparency/Charts/ACNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/ACNVChart.tsx
@@ -18,7 +18,9 @@ export function ACNVChart({ fontSize }: { fontSize: string }) {
   const error = acnvData.error
   return (
     <ChartCard {...acnvData} chartTitle="aCNV redeem counter">
-      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
+      {dataLoaded && error && (
+        <Text>{`Error fetching data, retrying in ${acnvData.nextTriggerByError} seconds`}</Text>
+      )}
       {dataLoaded && !error && (
         <>
           <Text color={'text.low'} lineHeight={'100%'}>

--- a/apps/cave/components/Transparency/Charts/ACNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/ACNVChart.tsx
@@ -18,7 +18,7 @@ export function ACNVChart({ fontSize }: { fontSize: string }) {
   const error = acnvData.error
   return (
     <ChartCard {...acnvData} chartTitle="aCNV redeem counter">
-      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
+      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
       {dataLoaded && !error && (
         <>
           <Text color={'text.low'} lineHeight={'100%'}>

--- a/apps/cave/components/Transparency/Charts/BbtCNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/BbtCNVChart.tsx
@@ -1,5 +1,4 @@
 import { Flex, Text, useBreakpointValue } from '@concave/ui'
-import { useEffect, useState } from 'react'
 import {
   Bar,
   BarChart,
@@ -13,8 +12,8 @@ import {
 import { numberWithCommas } from 'utils/numbersWithCommas'
 import { ChartCard } from './ChartCard'
 import { ChartTooltip } from './ChartTooltip'
-import { fetchData } from './fetchData'
 import { CHART_COLORS } from './style'
+import { useFetchData } from './useFetchData'
 
 type BbtCNVChartData = {
   bbtCNVRedeemable: number
@@ -24,44 +23,37 @@ type BbtCNVChartData = {
 }
 
 export function BbtCNVChart() {
-  const [data, setData] = useState<undefined | BbtCNVChartData[]>()
-  const [error, setError] = useState<undefined | string>()
-  const [dataLoaded, setDataLoaded] = useState(false)
   const isMobile = useBreakpointValue({ base: true, md: false })
-
-  useEffect(() => {
-    fetchData('bbtcnv-redeemed')
-      .then((data: BbtCNVChartData) => setData([data]))
-      .catch((error: Error) => setError(error.message))
-      .finally(() => setDataLoaded(true))
-  }, [])
-
+  const bbtCNVData = useFetchData<BbtCNVChartData>('bbtcnv-redeemed')
+  const dataLoaded = !bbtCNVData.isLoading
+  const data = bbtCNVData.data
+  const error = bbtCNVData.error
   return (
     <ChartCard
-      dataLoaded={dataLoaded}
+      {...bbtCNVData}
       chartTitle="bbtCNV redeem counter"
       tooltipDescription="bbtCNV redeem counter."
       overflow="visible"
     >
-      {dataLoaded && error && <Text>{error}</Text>}
+      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
       {dataLoaded && !error && (
         <>
           <Flex direction={'row'} gap={6} justifyContent={'space-evenly'}>
             <Flex direction={'column'} gap={1}>
               <Text fontSize={isMobile ? 'md' : '2xl'} lineHeight={'100%'}>
-                {numberWithCommas(data[0].bbtCNVRedeemable.toFixed(4))}
+                {numberWithCommas(data.bbtCNVRedeemable.toFixed(4))}
               </Text>
               <Text lineHeight={'100%'}>bbtCNV redeemable</Text>
             </Flex>
             <Flex direction={'column'} gap={1}>
               <Text fontSize={isMobile ? 'md' : '2xl'} lineHeight={'100%'}>
-                {numberWithCommas(data[0].bbtCNVRedeemed.toFixed(4))}
+                {numberWithCommas(data.bbtCNVRedeemed.toFixed(4))}
               </Text>
               <Text lineHeight={'100%'}>bbtCNV redeemed</Text>
             </Flex>
             <Flex direction={'column'} gap={1}>
               <Text fontSize={isMobile ? 'md' : '2xl'} lineHeight={'100%'}>
-                {numberWithCommas(data[0].bbtCNVToVest.toFixed(4))}
+                {numberWithCommas(data.bbtCNVToVest.toFixed(4))}
               </Text>
               <Text lineHeight={'100%'}>bbtCNV vesting</Text>
             </Flex>
@@ -71,7 +63,7 @@ export function BbtCNVChart() {
               layout="vertical"
               width={500}
               height={150}
-              data={data}
+              data={[data]}
               margin={{
                 top: 20,
                 right: 30,
@@ -84,7 +76,7 @@ export function BbtCNVChart() {
               <XAxis
                 type="number"
                 dataKey="TOTAL_BBTCNV"
-                domain={[0, Math.ceil(data[0].TOTAL_BBTCNV)]}
+                domain={[0, Math.ceil(data.TOTAL_BBTCNV)]}
                 tickFormatter={(v) => v.toLocaleString()}
                 tickLine={{ stroke: CHART_COLORS.TextLow }}
                 axisLine={{ stroke: CHART_COLORS.TextLow }}

--- a/apps/cave/components/Transparency/Charts/BbtCNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/BbtCNVChart.tsx
@@ -35,7 +35,9 @@ export function BbtCNVChart() {
       tooltipDescription="bbtCNV redeem counter."
       overflow="visible"
     >
-      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
+      {dataLoaded && error && (
+        <Text>{`Error fetching data, retrying in ${bbtCNVData.nextTriggerByError} seconds`}</Text>
+      )}
       {dataLoaded && !error && (
         <>
           <Flex direction={'row'} gap={6} justifyContent={'space-evenly'}>

--- a/apps/cave/components/Transparency/Charts/BbtCNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/BbtCNVChart.tsx
@@ -35,7 +35,7 @@ export function BbtCNVChart() {
       tooltipDescription="bbtCNV redeem counter."
       overflow="visible"
     >
-      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
+      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
       {dataLoaded && !error && (
         <>
           <Flex direction={'row'} gap={6} justifyContent={'space-evenly'}>

--- a/apps/cave/components/Transparency/Charts/ChartCard.tsx
+++ b/apps/cave/components/Transparency/Charts/ChartCard.tsx
@@ -31,7 +31,7 @@ export const ChartCard = ({
   overflow?: 'hidden' | 'visible'
   children?: JSX.Element | JSX.Element[]
 }) => {
-  const loadingMessage = failureCount ? `Retrying ... ( ${failureCount} )` : 'Loading data'
+  const loadingMessage = failureCount ? `Retrying...` : 'Loading data'
 
   return (
     <Card fontWeight={'bold'} variant={variant} w={width} p={p} h={height}>

--- a/apps/cave/components/Transparency/Charts/ChartCard.tsx
+++ b/apps/cave/components/Transparency/Charts/ChartCard.tsx
@@ -1,10 +1,11 @@
 import { QuestionIcon } from '@concave/icons'
-import { Box, Card, Flex, Text, Tooltip } from '@concave/ui'
+import { Box, Card, Flex, Spinner, Text, Tooltip } from '@concave/ui'
 import { Loading } from 'components/Loading'
 
 export const ChartCard = ({
+  isFetching,
+  isRefetching,
   chartTitle,
-  dataLoaded,
   tooltipDescription,
   variant = 'secondary',
   width = 'full',
@@ -12,9 +13,14 @@ export const ChartCard = ({
   p = 4,
   overflow = 'hidden',
   children,
+  failureCount,
+  data,
 }: {
+  data: unknown
   chartTitle: string
-  dataLoaded: boolean
+  isFetching?: boolean
+  isRefetching?: boolean
+  failureCount?: number
   tooltipDescription?: string
   variant?: 'primary' | 'secondary'
   width?: string
@@ -23,10 +29,13 @@ export const ChartCard = ({
   overflow?: 'hidden' | 'visible'
   children?: JSX.Element | JSX.Element[]
 }) => {
+  const loadingMessage = failureCount ? `Retrying ... ( ${failureCount} )` : 'Loading data'
+
   return (
     <Card fontWeight={'bold'} variant={variant} w={width} p={p} h={height}>
       <Box display={'flex'} flexDir={'row'} width={'full'} justifyContent={'space-between'}>
-        <Text>{chartTitle}</Text>
+        <Text mr={2}>{chartTitle}</Text>
+        {(isFetching || isRefetching) && <Spinner size={'sm'} mr={'auto'} />}
         {tooltipDescription && (
           <Tooltip label={tooltipDescription} shouldWrapChildren>
             <QuestionIcon />
@@ -42,7 +51,11 @@ export const ChartCard = ({
         justifyContent={'center'}
         alignItems={overflow === 'visible' ? 'center' : 'unset'}
       >
-        {dataLoaded ? <>{children}</> : <Loading size={'md'} label={'Loading data'} isLoading />}
+        {data != undefined ? (
+          <>{children}</>
+        ) : (
+          <Loading size={'md'} label={loadingMessage} isLoading />
+        )}
       </Flex>
     </Card>
   )

--- a/apps/cave/components/Transparency/Charts/ChartCard.tsx
+++ b/apps/cave/components/Transparency/Charts/ChartCard.tsx
@@ -31,7 +31,7 @@ export const ChartCard = ({
   overflow?: 'hidden' | 'visible'
   children?: JSX.Element | JSX.Element[]
 }) => {
-  const loadingMessage = failureCount ? `Retrying...` : 'Loading data'
+  const loadingMessage = failureCount ? `Retrying` : 'Loading data'
 
   return (
     <Card fontWeight={'bold'} variant={variant} w={width} p={p} h={height}>

--- a/apps/cave/components/Transparency/Charts/ChartCard.tsx
+++ b/apps/cave/components/Transparency/Charts/ChartCard.tsx
@@ -3,6 +3,7 @@ import { Box, Card, Flex, Spinner, Text, Tooltip } from '@concave/ui'
 import { Loading } from 'components/Loading'
 
 export const ChartCard = ({
+  isLoading,
   isFetching,
   isRefetching,
   chartTitle,
@@ -19,6 +20,7 @@ export const ChartCard = ({
   data: unknown
   chartTitle: string
   isFetching?: boolean
+  isLoading?: boolean
   isRefetching?: boolean
   failureCount?: number
   tooltipDescription?: string
@@ -51,11 +53,7 @@ export const ChartCard = ({
         justifyContent={'center'}
         alignItems={overflow === 'visible' ? 'center' : 'unset'}
       >
-        {data != undefined ? (
-          <>{children}</>
-        ) : (
-          <Loading size={'md'} label={loadingMessage} isLoading />
-        )}
+        {!isLoading ? <>{children}</> : <Loading size={'md'} label={loadingMessage} isLoading />}
       </Flex>
     </Card>
   )

--- a/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
@@ -24,7 +24,9 @@ export function LockedCNVChart({ width, fontSize }: { width: string; fontSize: s
       width={width}
       overflow={'visible'}
     >
-      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
+      {dataLoaded && error && (
+        <Text>{`Error fetching data, retrying in ${amountLocked.nextTriggerByError} seconds`}</Text>
+      )}
       {dataLoaded && !error && (
         <>
           <Text color={'text.low'} lineHeight={'100%'}>

--- a/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
@@ -24,7 +24,7 @@ export function LockedCNVChart({ width, fontSize }: { width: string; fontSize: s
       width={width}
       overflow={'visible'}
     >
-      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
+      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
       {dataLoaded && !error && (
         <>
           <Text color={'text.low'} lineHeight={'100%'}>

--- a/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
@@ -4,13 +4,15 @@ import { ChartCard } from './ChartCard'
 import { useFetchData } from './useFetchData'
 
 type AmountCNVLockedData = {
-  ConcaveTokenTotalSupply: number
-  sumAmountLocked: number
+  ratioSupply: number
+  ratio: number
   ratioStaked: number
 }
-
 export function LockedCNVChart({ width, fontSize }: { width: string; fontSize: string }) {
-  const amountLocked = useFetchData<AmountCNVLockedData>('locked')
+  const amountLocked = useFetchData<AmountCNVLockedData>(
+    'ratio',
+    'https://cnv-data.concave.lol/api',
+  )
   const dataLoaded = !amountLocked.isLoading
   const data = amountLocked.data
   const error = amountLocked.error
@@ -26,12 +28,12 @@ export function LockedCNVChart({ width, fontSize }: { width: string; fontSize: s
       {dataLoaded && !error && (
         <>
           <Text color={'text.low'} lineHeight={'100%'}>
-            {numberWithCommas(data.sumAmountLocked.toFixed(4))}
+            {numberWithCommas(data.ratioStaked.toFixed(4))}
             {' / '}
-            {numberWithCommas(data.ConcaveTokenTotalSupply.toFixed(4))} CNV
+            {numberWithCommas(data.ratioSupply.toFixed(4))} CNV
           </Text>
           <Text lineHeight={'100%'} fontSize={fontSize}>
-            {(data.ratioStaked * 100).toFixed(2)}%
+            {(data.ratio * 100).toFixed(2)}%
           </Text>
           <Text fontSize={'large'}>CNV locked in lsdCNV</Text>
         </>

--- a/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVChart.tsx
@@ -1,45 +1,37 @@
 import { Text } from '@concave/ui'
-import { useEffect, useState } from 'react'
 import { numberWithCommas } from 'utils/numbersWithCommas'
 import { ChartCard } from './ChartCard'
-import { fetchData } from './fetchData'
+import { useFetchData } from './useFetchData'
 
 type AmountCNVLockedData = {
-  ratioSupply: number
-  ratio: number
+  ConcaveTokenTotalSupply: number
+  sumAmountLocked: number
   ratioStaked: number
 }
 
 export function LockedCNVChart({ width, fontSize }: { width: string; fontSize: string }) {
-  const [data, setData] = useState<undefined | AmountCNVLockedData>()
-  const [error, setError] = useState<undefined | string>()
-  const [dataLoaded, setDataLoaded] = useState(false)
-
-  useEffect(() => {
-    fetchData('ratio', 'https://cnv-data.concave.lol/api')
-      .then((data: AmountCNVLockedData) => setData(data))
-      .catch((error: Error) => setError(error.message))
-      .finally(() => setDataLoaded(true))
-  }, [])
-
+  const amountLocked = useFetchData<AmountCNVLockedData>('locked')
+  const dataLoaded = !amountLocked.isLoading
+  const data = amountLocked.data
+  const error = amountLocked.error
   return (
     <ChartCard
-      dataLoaded={dataLoaded}
+      {...amountLocked}
       chartTitle="CNV in lsdCNV"
       tooltipDescription="Calculated using amountLocked / totalSupply."
       width={width}
       overflow={'visible'}
     >
-      {dataLoaded && error && <Text>{error}</Text>}
+      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
       {dataLoaded && !error && (
         <>
           <Text color={'text.low'} lineHeight={'100%'}>
-            {numberWithCommas(data.ratioStaked.toFixed(4))}
+            {numberWithCommas(data.sumAmountLocked.toFixed(4))}
             {' / '}
-            {numberWithCommas(data.ratioSupply.toFixed(4))} CNV
+            {numberWithCommas(data.ConcaveTokenTotalSupply.toFixed(4))} CNV
           </Text>
           <Text lineHeight={'100%'} fontSize={fontSize}>
-            {(data.ratio * 100).toFixed(2)}%
+            {(data.ratioStaked * 100).toFixed(2)}%
           </Text>
           <Text fontSize={'large'}>CNV locked in lsdCNV</Text>
         </>

--- a/apps/cave/components/Transparency/Charts/LockedCNVSeriesChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVSeriesChart.tsx
@@ -1,5 +1,4 @@
 import { Text, useBreakpointValue } from '@concave/ui'
-import { useEffect, useState } from 'react'
 import {
   CartesianGrid,
   Label,
@@ -13,8 +12,8 @@ import {
 import { ChartCard } from './ChartCard'
 import { ChartTooltip } from './ChartTooltip'
 import { CustomizedAxisTick } from './CustomizedAxisTick'
-import { fetchData } from './fetchData'
 import { CHART_COLORS } from './style'
+import { useFetchData } from './useFetchData'
 
 type lockedCNVDatum = { timestamp: number; locked: number; date: string }
 
@@ -24,9 +23,6 @@ type LockedCNVSeriesData = {
 }
 
 export const LockedCNVSeriesChart = () => {
-  const [data, setData] = useState<undefined | LockedCNVSeriesData>()
-  const [error, setError] = useState<undefined | string>()
-  const [dataLoaded, setDataLoaded] = useState(false)
   const isMobile = useBreakpointValue({ base: true, md: false })
 
   let chartMargin = {
@@ -43,17 +39,14 @@ export const LockedCNVSeriesChart = () => {
     xLabelPos = { y: '47.5px' }
     yLabelPos = { x: '-105px', y: '180px' }
   }
-
-  useEffect(() => {
-    fetchData('locked-series')
-      .then((data: LockedCNVSeriesData) => setData(data))
-      .catch((error: Error) => setError(error.message))
-      .finally(() => setDataLoaded(true))
-  }, [])
+  const lockedCNVSeries = useFetchData<LockedCNVSeriesData>('locked-series')
+  const dataLoaded = !lockedCNVSeries.isLoading
+  const data = lockedCNVSeries.data
+  const error = lockedCNVSeries.error
 
   return (
-    <ChartCard dataLoaded={dataLoaded} chartTitle="CNV locked over time">
-      {dataLoaded && error && <Text>{error}</Text>}
+    <ChartCard {...lockedCNVSeries} chartTitle="CNV locked over time">
+      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
       {dataLoaded && !error && (
         <ResponsiveContainer width="100%" height="100%">
           <LineChart width={500} height={300} data={data.lockedCNV} margin={chartMargin}>

--- a/apps/cave/components/Transparency/Charts/LockedCNVSeriesChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVSeriesChart.tsx
@@ -46,7 +46,9 @@ export const LockedCNVSeriesChart = () => {
 
   return (
     <ChartCard {...lockedCNVSeries} chartTitle="CNV locked over time">
-      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
+      {dataLoaded && error && (
+        <Text>{`Error fetching data, retrying in ${lockedCNVSeries.nextTriggerByError} seconds`}</Text>
+      )}
       {dataLoaded && !error && (
         <ResponsiveContainer width="100%" height="100%">
           <LineChart width={500} height={300} data={data.lockedCNV} margin={chartMargin}>

--- a/apps/cave/components/Transparency/Charts/LockedCNVSeriesChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVSeriesChart.tsx
@@ -46,7 +46,7 @@ export const LockedCNVSeriesChart = () => {
 
   return (
     <ChartCard {...lockedCNVSeries} chartTitle="CNV locked over time">
-      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
+      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
       {dataLoaded && !error && (
         <ResponsiveContainer width="100%" height="100%">
           <LineChart width={500} height={300} data={data.lockedCNV} margin={chartMargin}>

--- a/apps/cave/components/Transparency/Charts/LsdCNVUniqueHolders.tsx
+++ b/apps/cave/components/Transparency/Charts/LsdCNVUniqueHolders.tsx
@@ -21,7 +21,7 @@ export function LsdCNVHoldersChart({ width, fontSize }: { width: string; fontSiz
       tooltipDescription="The amount of unique lsdCNV holders."
       width={width}
     >
-      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
+      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
       {dataLoaded && !error && (
         <>
           <Text lineHeight={'100%'} fontSize={fontSize}>

--- a/apps/cave/components/Transparency/Charts/LsdCNVUniqueHolders.tsx
+++ b/apps/cave/components/Transparency/Charts/LsdCNVUniqueHolders.tsx
@@ -1,7 +1,6 @@
 import { Text } from '@concave/ui'
-import { useEffect, useState } from 'react'
 import { ChartCard } from './ChartCard'
-import { fetchData } from './fetchData'
+import { useFetchData } from './useFetchData'
 
 type LsdCNVHoldersData = {
   aggregate: {
@@ -10,25 +9,19 @@ type LsdCNVHoldersData = {
 }
 
 export function LsdCNVHoldersChart({ width, fontSize }: { width: string; fontSize: string }) {
-  const [data, setData] = useState<undefined | LsdCNVHoldersData>()
-  const [error, setError] = useState<undefined | string>()
-  const [dataLoaded, setDataLoaded] = useState(false)
-
-  useEffect(() => {
-    fetchData('lsdcnv-unique-holders')
-      .then((data: LsdCNVHoldersData) => setData(data))
-      .catch((error: Error) => setError(error.message))
-      .finally(() => setDataLoaded(true))
-  }, [])
+  const fetchResult = useFetchData<LsdCNVHoldersData>('lsdcnv-unique-holders')
+  const dataLoaded = !fetchResult.isLoading
+  const data = fetchResult.data
+  const error = fetchResult.error
 
   return (
     <ChartCard
-      dataLoaded={dataLoaded}
+      {...fetchResult}
       chartTitle="lsdCNV holders"
       tooltipDescription="The amount of unique lsdCNV holders."
       width={width}
     >
-      {dataLoaded && error && <Text>{error}</Text>}
+      {dataLoaded && error && <Text>{`Error to fetch result, we will refetch`}</Text>}
       {dataLoaded && !error && (
         <>
           <Text lineHeight={'100%'} fontSize={fontSize}>

--- a/apps/cave/components/Transparency/Charts/LsdCNVUniqueHolders.tsx
+++ b/apps/cave/components/Transparency/Charts/LsdCNVUniqueHolders.tsx
@@ -9,19 +9,21 @@ type LsdCNVHoldersData = {
 }
 
 export function LsdCNVHoldersChart({ width, fontSize }: { width: string; fontSize: string }) {
-  const fetchResult = useFetchData<LsdCNVHoldersData>('lsdcnv-unique-holders')
-  const dataLoaded = !fetchResult.isLoading
-  const data = fetchResult.data
-  const error = fetchResult.error
+  const lsdCNVHolders = useFetchData<LsdCNVHoldersData>('lsdcnv-unique-holders')
+  const dataLoaded = !lsdCNVHolders.isLoading
+  const data = lsdCNVHolders.data
+  const error = lsdCNVHolders.error
 
   return (
     <ChartCard
-      {...fetchResult}
+      {...lsdCNVHolders}
       chartTitle="lsdCNV holders"
       tooltipDescription="The amount of unique lsdCNV holders."
       width={width}
     >
-      {dataLoaded && error && <Text>{`Error fetching data, retrying`}</Text>}
+      {dataLoaded && error && (
+        <Text>{`Error fetching data, retrying in ${lsdCNVHolders.nextTriggerByError} seconds`}</Text>
+      )}
       {dataLoaded && !error && (
         <>
           <Text lineHeight={'100%'} fontSize={fontSize}>

--- a/apps/cave/components/Transparency/Charts/fetchData.ts
+++ b/apps/cave/components/Transparency/Charts/fetchData.ts
@@ -1,12 +1,12 @@
 import { NEXT_PUBLIC_CHART_ENDPOINT } from 'lib/env.conf'
 
-export async function fetchData(
+export async function fetchData<T = unknown>(
   route: string,
   url: string = NEXT_PUBLIC_CHART_ENDPOINT,
   method?: string,
   bodyData?: object,
-): Promise<any> {
-  return fetch(`${url}/${route}`, {
+): Promise<T> {
+  const response = await fetch(`${url}/${route}`, {
     method: method || 'GET',
     mode: 'cors',
     redirect: 'follow',
@@ -14,13 +14,11 @@ export async function fetchData(
       'Content-Type': 'application/json',
     },
     body: bodyData ? JSON.stringify(bodyData) : null,
-  }).then((response) =>
-    response.json().then((responseJson) => {
-      const data = responseJson.data
-      if (data.status === 400) {
-        throw new Error(data.msg)
-      }
-      return data
-    }),
-  )
+  })
+  const responseJson = await response.json()
+  const data = responseJson.data
+  if (data.status === 400) {
+    throw new Error(data.msg)
+  }
+  return data as T
 }

--- a/apps/cave/components/Transparency/Charts/useFetchData.ts
+++ b/apps/cave/components/Transparency/Charts/useFetchData.ts
@@ -20,7 +20,7 @@ export const useFetchData = <T>(
     () => fetchData<T>(route, url, method, bodyData),
     {
       retry: 3,
-      refetchInterval: 15000,
+      refetchInterval: 60000,
       retryDelay: 5000,
       refetchOnWindowFocus: false,
       refetchOnMount: false,

--- a/apps/cave/components/Transparency/Charts/useFetchData.ts
+++ b/apps/cave/components/Transparency/Charts/useFetchData.ts
@@ -1,0 +1,31 @@
+import { NEXT_PUBLIC_CHART_ENDPOINT } from 'lib/env.conf'
+import { useQuery, UseQueryResult } from 'react-query'
+import { fetchData } from './fetchData'
+
+export const useFetchData = <T>(
+  route: string,
+  url: string = NEXT_PUBLIC_CHART_ENDPOINT,
+  method?: string,
+  bodyData?: object,
+): UseQueryResult<T, unknown> => {
+  return useQuery(
+    [
+      JSON.stringify({
+        route,
+        url,
+        method,
+        bodyData,
+      }),
+    ],
+    () => fetchData<T>(route, url, method, bodyData),
+    {
+      retry: 3,
+      refetchInterval: 15000,
+      retryDelay: 5000,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchIntervalInBackground: true,
+    },
+  )
+}

--- a/apps/cave/components/Transparency/Charts/useFetchData.ts
+++ b/apps/cave/components/Transparency/Charts/useFetchData.ts
@@ -1,4 +1,6 @@
+import { useInterval } from '@concave/ui'
 import { NEXT_PUBLIC_CHART_ENDPOINT } from 'lib/env.conf'
+import { useEffect, useState } from 'react'
 import { useQuery, UseQueryResult } from 'react-query'
 import { fetchData } from './fetchData'
 
@@ -7,8 +9,8 @@ export const useFetchData = <T>(
   url: string = NEXT_PUBLIC_CHART_ENDPOINT,
   method?: string,
   bodyData?: object,
-): UseQueryResult<T, unknown> => {
-  return useQuery(
+): UseQueryResult<T, unknown> & { nextTriggerByError: number } => {
+  const useQueryResult = useQuery(
     [
       JSON.stringify({
         route,
@@ -20,12 +22,32 @@ export const useFetchData = <T>(
     () => fetchData<T>(route, url, method, bodyData),
     {
       retry: 3,
-      refetchInterval: 60000,
-      retryDelay: 5000,
+      refetchInterval: 600_000, // refetch on success
+      keepPreviousData: true,
+      retryDelay: 2_000,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchIntervalInBackground: true,
     },
   )
+  const { nextTriggerByError } = useQueryStaleErrorRetry(useQueryResult)
+  return { ...useQueryResult, nextTriggerByError }
+}
+
+const useQueryStaleErrorRetry = (useQueryResult: UseQueryResult<unknown, unknown>) => {
+  // Refetch when error and stale after 1 min
+  const [nextTriggerByError, setNextTrigger] = useState(-1)
+  useInterval(() => setNextTrigger((prev) => prev - 1), 1000)
+  useEffect(() => {
+    if (nextTriggerByError === 0) {
+      useQueryResult.refetch()
+      return
+    }
+    if (nextTriggerByError > 0) return
+    if (useQueryResult.isStale && useQueryResult.isError) {
+      setNextTrigger(60)
+    }
+  })
+  return { nextTriggerByError }
 }

--- a/apps/cave/pages/faucet.tsx
+++ b/apps/cave/pages/faucet.tsx
@@ -1,85 +1,37 @@
-import { CNV, Currency, CurrencyAmount } from '@concave/core'
-import { Box, Button, Card, Flex, Heading, Text } from '@concave/ui'
-import { CurrencyInputField } from 'components/CurrencyAmountField'
-import { SelectFaucetCurrency } from 'components/CurrencySelector/SelectFaucetCurrency'
+import { useBreakpointValue } from '@concave/ui'
 import { withPageTransition } from 'components/PageTransition'
-import { Contract } from 'ethers'
-import { useCurrentSupportedNetworkId } from 'hooks/useCurrentSupportedNetworkId'
-import { concaveProvider } from 'lib/providers'
-import { useState } from 'react'
-import { useAccount, useSigner } from 'wagmi'
+import { LockedCNVChart } from 'components/Transparency/Charts/LockedCNVChart'
 
 const Faucet = () => {
-  const chainId = useCurrentSupportedNetworkId()
-  const [inputAmount, setInputAmout] = useState<CurrencyAmount<Currency>>(
-    CurrencyAmount.fromRawAmount(CNV[chainId], '0'),
-  )
-  const { address } = useAccount()
-  const { data: signer } = useSigner()
+  const isMobile = useBreakpointValue({ base: true, md: false })
 
-  const mint = () => {
-    const provider = concaveProvider(chainId)
-    const contract = new Contract(
-      inputAmount.currency.wrapped.address,
-      ['function mint(address guy, uint256 wad) external'],
-      provider,
-    ).connect(signer)
-    contract.mint(address, inputAmount.quotient.toString())
+  let style
+  if (isMobile) {
+    style = {
+      textChartFontSize: '7xl',
+      lockedCnv: {
+        width: 'full',
+      },
+      lsdCnv: {
+        width: 'full',
+      },
+    }
+  } else {
+    style = {
+      textChartFontSize: '7xl',
+      lockedCnv: {
+        width: '60%',
+      },
+      lsdCnv: {
+        width: '50%',
+      },
+    }
   }
 
   return (
-    <Box maxH={'100vh'} w={'100%'} overflowY={'hidden'} apply="scrollbar.secondary">
-      <Flex
-        align={'center'}
-        w={'100%'}
-        borderRadius={0}
-        gap={4}
-        textAlign="center"
-        direction="column"
-      >
-        <>
-          <Heading as="h1" mt={16} mb={3} fontSize="5xl">
-            Faucet
-          </Heading>
-          <Flex mt={0} align="center" gap={10} width="full" justify="center" alignItems={'center'}>
-            <Text maxW={520} textAlign={'center'}>
-              Select and mint tokens
-            </Text>
-          </Flex>
-
-          <Flex
-            direction="column"
-            float={'left'}
-            position="relative"
-            justify={'center'}
-            align="center"
-            width="full"
-            gap={5}
-            p={{ base: 0, sm: 4 }}
-          >
-            <Card
-              p={6}
-              gap={6}
-              variant="primary"
-              h="fit-content"
-              shadow="Block Up"
-              w="100%"
-              maxW="420px"
-            >
-              <CurrencyInputField
-                currencyAmountIn={inputAmount}
-                onChangeAmount={setInputAmout}
-                CurrencySelector={SelectFaucetCurrency}
-              />
-
-              <Button variant="primary" size="large" w="full" onClick={mint}>
-                Mint
-              </Button>
-            </Card>
-          </Flex>
-        </>
-      </Flex>
-    </Box>
+    <>
+      <LockedCNVChart width={style.lockedCnv.width} fontSize={style.textChartFontSize} />
+    </>
   )
 }
 


### PR DESCRIPTION
## Description

On transparency overview page:
- Background refresh chart info for each minute
<img width="360" alt="Screen Shot 2022-11-01 at 18 06 00" src="https://user-images.githubusercontent.com/5888609/199341704-48f8e052-2106-4961-aaf7-d407be7026ed.png">


- Retry 3 times to fetch the chart info, if a error persist we will wait 1 min to retry 3 times again


<img width="312" alt="Screen Shot 2022-11-02 at 11 21 30" src="https://user-images.githubusercontent.com/5888609/199514853-b34b01d7-df99-4f69-a860-f7033ddbb03f.png">
<img width="312" alt="Screen Shot 2022-11-02 at 11 22 27" src="https://user-images.githubusercontent.com/5888609/199514877-6c4639c6-931c-499f-85ab-632b6b823ffd.png">


Implements CE-965 