### PR TITLE
Ce 921 mobile UI flow

### DIFF
--- a/apps/cave/components/TransparencyDiagram/ReactFlowDiagram.tsx
+++ b/apps/cave/components/TransparencyDiagram/ReactFlowDiagram.tsx
@@ -1,0 +1,38 @@
+import { useRef } from 'react'
+import ReactFlow, { ConnectionLineType, Controls, ReactFlowInstance } from 'react-flow-renderer'
+import { nodeTypes } from './nodes/nodes'
+import { edgeStyle, labelStyle } from './styles'
+
+export const ReactFlowDiagram = ({ edges, nodes, isMobile }) => {
+  const reactFlow = useRef<ReactFlowInstance>()
+  const onInit = (rf: ReactFlowInstance) => {
+    reactFlow.current = rf
+  }
+  reactFlow?.current?.fitView
+  return (
+    <>
+      <ReactFlow
+        edges={edges}
+        nodes={nodes}
+        nodeTypes={nodeTypes}
+        elevateEdgesOnSelect
+        fitViewOptions={{ padding: 0.05, includeHiddenNodes: true }}
+        fitView
+        minZoom={0}
+        zoomOnPinch
+        panOnDrag
+        onInit={onInit}
+        attributionPosition={'bottom-right'}
+        defaultEdgeOptions={{
+          type: ConnectionLineType.SimpleBezier,
+          animated: true,
+          style: { ...edgeStyle },
+          labelStyle: { ...labelStyle },
+          labelShowBg: false,
+        }}
+      >
+        {isMobile ? <></> : <Controls showInteractive={true} />}
+      </ReactFlow>
+    </>
+  )
+}

--- a/apps/cave/components/TransparencyDiagram/TransparencyDiagram.tsx
+++ b/apps/cave/components/TransparencyDiagram/TransparencyDiagram.tsx
@@ -8,10 +8,10 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
+  useBreakpointValue,
   VStack,
 } from '@concave/ui'
 import { Dispatch, SetStateAction, useState } from 'react'
-import ReactFlow, { ConnectionLineType, Controls } from 'react-flow-renderer'
 import { bondingEdges } from './edges/bondingEdges'
 import { bondingEdgesMobile } from './edges/bondingEdgesMobile'
 import { generalEdges } from './edges/generalEdges'
@@ -23,11 +23,10 @@ import {
   bondingNodesMobile,
   generalNodes,
   generalNodesMobile,
-  nodeTypes,
   stakingNodes,
   stakingNodesMobile,
 } from './nodes/nodes'
-import { edgeStyle, labelStyle } from './styles'
+import { ReactFlowDiagram } from './ReactFlowDiagram'
 
 enum DiagramButtons {
   TreasuryOverview = 'Treasury Overview',
@@ -52,36 +51,17 @@ const DataStudio = ({ src }: { src: string }) => (
   <Flex src={src} as={'iframe'} w={'full'} h={'full'} overflow={'hidden'} rounded={'2xl'} />
 )
 
-const ReactFlowDiagram = ({ edges, nodes, isMobile }) => (
-  <ReactFlow
-    edges={edges}
-    nodes={nodes}
-    nodeTypes={nodeTypes}
-    elevateEdgesOnSelect
-    fitView
-    fitViewOptions={{ padding: 0.15 }}
-    minZoom={0}
-    zoomOnPinch
-    panOnDrag
-    defaultEdgeOptions={{
-      type: ConnectionLineType.SimpleBezier,
-      style: { ...edgeStyle },
-      labelStyle: { ...labelStyle },
-      labelShowBg: false,
-    }}
-  >
-    {isMobile ? <></> : <Controls showInteractive={false} />}
-  </ReactFlow>
-)
-
-export function TransparencyDiagram({ isMobile }: { isMobile: boolean }) {
-  const [diagramShown, setDiagramShown] = useState<DiagramButtons>(DiagramButtons.TreasuryOverview)
+export function TransparencyDiagram() {
+  const [diagramShown, setDiagramShown] = useState<DiagramButtons>(DiagramButtons.GeneralDiagram)
+  const isMobile = useBreakpointValue({ base: true, md: false })
 
   return (
     <>
-      <VStack
-        w={'100%'}
+      <Flex
+        direction={'column'}
+        width={'100%'}
         height={'800px'}
+        maxHeight={'90vh'}
         rounded={'2xl'}
         apply="background.metalBrighter"
         shadow={'up'}
@@ -98,8 +78,6 @@ export function TransparencyDiagram({ isMobile }: { isMobile: boolean }) {
           shadow="down"
           w={'100%'}
           h="full"
-          p={isMobile ? 2 : 4}
-          py={isMobile ? 2 : 6}
           justify="start"
           overflowY={'auto'}
           direction="column"
@@ -156,7 +134,7 @@ export function TransparencyDiagram({ isMobile }: { isMobile: boolean }) {
             />
           )}
         </Flex>
-      </VStack>
+      </Flex>
     </>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/TransparencyDiagram.tsx
+++ b/apps/cave/components/TransparencyDiagram/TransparencyDiagram.tsx
@@ -8,7 +8,6 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
-  useBreakpointValue,
   VStack,
 } from '@concave/ui'
 import { Dispatch, SetStateAction, useState } from 'react'
@@ -51,22 +50,21 @@ const DataStudio = ({ src }: { src: string }) => (
   <Flex src={src} as={'iframe'} w={'full'} h={'full'} overflow={'hidden'} rounded={'2xl'} />
 )
 
-export function TransparencyDiagram() {
+export function TransparencyDiagram({ isMobile }: { isMobile: boolean }) {
   const [diagramShown, setDiagramShown] = useState<DiagramButtons>(DiagramButtons.TreasuryOverview)
-  const isMobile = useBreakpointValue({ base: true, md: false })
 
   return (
     <>
-      <Flex
-        direction={'column'}
-        width={'100%'}
+      <VStack
+        w={'100%'}
         height={'800px'}
-        maxHeight={'90vh'}
         rounded={'2xl'}
         apply="background.metalBrighter"
         shadow={'up'}
-        p={5}
-        gap={5}
+        minH={'500px'}
+        maxH={{ base: '90vh', md: '800px' }}
+        p={{ base: 4, sm: 5 }}
+        gap={{ base: 2, sm: 5 }}
       >
         {isMobile ? (
           <MobileMenu diagramShown={diagramShown} setDiagramShown={setDiagramShown} />
@@ -78,6 +76,8 @@ export function TransparencyDiagram() {
           shadow="down"
           w={'100%'}
           h="full"
+          p={isMobile ? 2 : 4}
+          py={isMobile ? 2 : 6}
           justify="start"
           overflowY={'auto'}
           direction="column"
@@ -134,7 +134,7 @@ export function TransparencyDiagram() {
             />
           )}
         </Flex>
-      </Flex>
+      </VStack>
     </>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/TransparencyDiagram.tsx
+++ b/apps/cave/components/TransparencyDiagram/TransparencyDiagram.tsx
@@ -52,7 +52,7 @@ const DataStudio = ({ src }: { src: string }) => (
 )
 
 export function TransparencyDiagram() {
-  const [diagramShown, setDiagramShown] = useState<DiagramButtons>(DiagramButtons.GeneralDiagram)
+  const [diagramShown, setDiagramShown] = useState<DiagramButtons>(DiagramButtons.TreasuryOverview)
   const isMobile = useBreakpointValue({ base: true, md: false })
 
   return (

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Bond.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Bond.tsx
@@ -1,16 +1,11 @@
-import { Box, Link, useBreakpointValue } from '@concave/ui'
+import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
 import { Handle, Position } from 'react-flow-renderer'
 import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
-import { NodeDisplayData, ShapeLabelSettingsType } from '../../types'
+import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
 
 export function Bond({ data }: { data: NodeDisplayData }) {
-  const isMobile = useBreakpointValue({ base: true, md: false })
-  const shapeSettings: ShapeLabelSettingsType = {
-    labelBottom: '-50px',
-  }
-
   const explorerURL = getExplorerURL(data)
 
   return (
@@ -19,51 +14,50 @@ export function Bond({ data }: { data: NodeDisplayData }) {
         type="target"
         position={Position.Top}
         id="topTarget"
-        style={{ ...sharedNodeHandleStyle, top: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Top}
         id="topSource"
-        style={{ ...sharedNodeHandleStyle, top: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Bottom}
         id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle, bottom: isMobile ? -110 : -66 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Bottom}
         id="bottomSource"
-        style={{ ...sharedNodeHandleStyle, bottom: isMobile ? -110 : -66 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Right}
         id="rightSource"
-        style={{ ...sharedNodeHandleStyle, right: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Right}
         id="rightTarget"
-        style={{ ...sharedNodeHandleStyle, right: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Left}
         id="leftSource"
-        style={{ ...sharedNodeHandleStyle, left: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Left}
         id="leftTarget"
-        style={{ ...sharedNodeHandleStyle, left: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
-      <NodeText data={data} shapeSettings={shapeSettings} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="210"
@@ -146,6 +140,8 @@ export function Bond({ data }: { data: NodeDisplayData }) {
           </defs>
         </svg>
       </Link>
+
+      <NodeText data={data} />
     </Box>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Bond.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Bond.tsx
@@ -1,63 +1,16 @@
 import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
-import { Handle, Position } from 'react-flow-renderer'
-import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
+import { sharedNodeContainerStyle } from '../../styles'
 import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
+import { Handles } from './Handles'
 
 export function Bond({ data }: { data: NodeDisplayData }) {
   const explorerURL = getExplorerURL(data)
 
   return (
     <Box sx={{ ...sharedNodeContainerStyle }}>
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="topTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="topSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Bottom}
-        id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottomSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="rightSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Right}
-        id="rightTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="leftSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="leftTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
+      <Handles top={61} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="210"

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Handles.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Handles.tsx
@@ -1,0 +1,57 @@
+import { Handle, Position } from 'react-flow-renderer'
+import { sharedNodeHandleStyle } from '../../styles'
+
+export const Handles = ({ top }: { top?: number }) => {
+  return (
+    <>
+      <Handle
+        type="target"
+        position={Position.Top}
+        id="topTarget"
+        style={{ ...sharedNodeHandleStyle }}
+      />
+      <Handle
+        type="source"
+        position={Position.Top}
+        id="topSource"
+        style={{ ...sharedNodeHandleStyle }}
+      />
+      <Handle
+        type="target"
+        position={Position.Bottom}
+        id="bottomTarget"
+        style={{ ...sharedNodeHandleStyle }}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottomSource"
+        style={{ ...sharedNodeHandleStyle }}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="rightSource"
+        style={{ ...sharedNodeHandleStyle, top }}
+      />
+      <Handle
+        type="target"
+        position={Position.Right}
+        id="rightTarget"
+        style={{ ...sharedNodeHandleStyle, top }}
+      />
+      <Handle
+        type="source"
+        position={Position.Left}
+        id="leftSource"
+        style={{ ...sharedNodeHandleStyle, top }}
+      />
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="leftTarget"
+        style={{ ...sharedNodeHandleStyle, top }}
+      />
+    </>
+  )
+}

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Multisig.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Multisig.tsx
@@ -1,63 +1,16 @@
 import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
-import { Handle, Position } from 'react-flow-renderer'
-import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
+import { sharedNodeContainerStyle } from '../../styles'
 import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
+import { Handles } from './Handles'
 
 export function Multisig({ data }: { data: NodeDisplayData }) {
   const explorerURL = getExplorerURL(data)
 
   return (
-    <Box sx={{ ...sharedNodeContainerStyle }}>
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="topTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="topSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Bottom}
-        id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottomSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="rightSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Right}
-        id="rightTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />{' '}
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="leftSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="leftTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
+    <Box sx={{ ...sharedNodeContainerStyle }} maxW={'133px'}>
+      <Handles top={70} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="123"

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Multisig.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Multisig.tsx
@@ -1,16 +1,11 @@
-import { Box, Link, useBreakpointValue } from '@concave/ui'
+import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
 import { Handle, Position } from 'react-flow-renderer'
 import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
-import { NodeDisplayData, ShapeLabelSettingsType } from '../../types'
+import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
 
 export function Multisig({ data }: { data: NodeDisplayData }) {
-  const isMobile = useBreakpointValue({ base: true, md: false })
-  const shapeSettings: ShapeLabelSettingsType = {
-    labelBottom: '-50',
-  }
-
   const explorerURL = getExplorerURL(data)
 
   return (
@@ -19,51 +14,50 @@ export function Multisig({ data }: { data: NodeDisplayData }) {
         type="target"
         position={Position.Top}
         id="topTarget"
-        style={{ ...sharedNodeHandleStyle, top: -20 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Top}
         id="topSource"
-        style={{ ...sharedNodeHandleStyle, top: -20 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Bottom}
         id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle, bottom: isMobile ? -110 : -66 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Bottom}
         id="bottomSource"
-        style={{ ...sharedNodeHandleStyle, bottom: isMobile ? -110 : -66 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Right}
         id="rightSource"
-        style={{ ...sharedNodeHandleStyle, right: -18 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Right}
         id="rightTarget"
-        style={{ ...sharedNodeHandleStyle, right: -18 }}
+        style={{ ...sharedNodeHandleStyle }}
       />{' '}
       <Handle
         type="source"
         position={Position.Left}
         id="leftSource"
-        style={{ ...sharedNodeHandleStyle, left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Left}
         id="leftTarget"
-        style={{ ...sharedNodeHandleStyle, left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
-      <NodeText data={data} shapeSettings={shapeSettings} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="123"
@@ -203,6 +197,7 @@ export function Multisig({ data }: { data: NodeDisplayData }) {
           </defs>
         </svg>
       </Link>
+      <NodeText data={data} />
     </Box>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/ProxyAdmin.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/ProxyAdmin.tsx
@@ -1,63 +1,16 @@
 import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
-import { Handle, Position } from 'react-flow-renderer'
-import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
+import { sharedNodeContainerStyle } from '../../styles'
 import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
+import { Handles } from './Handles'
 
 export function ProxyAdmin({ data }: { data: NodeDisplayData }) {
   const explorerURL = getExplorerURL(data)
 
   return (
     <Box sx={{ ...sharedNodeContainerStyle }}>
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="topTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="topSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Bottom}
-        id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottomSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="rightSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Right}
-        id="rightTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />{' '}
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="leftSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="leftTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
+      <Handles top={51} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="149"

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/ProxyAdmin.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/ProxyAdmin.tsx
@@ -2,14 +2,10 @@ import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
 import { Handle, Position } from 'react-flow-renderer'
 import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
-import { NodeDisplayData, ShapeLabelSettingsType } from '../../types'
+import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
 
 export function ProxyAdmin({ data }: { data: NodeDisplayData }) {
-  const shapeSettings: ShapeLabelSettingsType = {
-    labelBottom: '-50',
-  }
-
   const explorerURL = getExplorerURL(data)
 
   return (
@@ -18,51 +14,50 @@ export function ProxyAdmin({ data }: { data: NodeDisplayData }) {
         type="target"
         position={Position.Top}
         id="topTarget"
-        style={{ ...sharedNodeHandleStyle, top: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Top}
         id="topSource"
-        style={{ ...sharedNodeHandleStyle, top: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Bottom}
         id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle, bottom: '-66px' }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Bottom}
         id="bottomSource"
-        style={{ ...sharedNodeHandleStyle, bottom: '-66px' }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Right}
         id="rightSource"
-        style={{ ...sharedNodeHandleStyle, right: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Right}
         id="rightTarget"
-        style={{ ...sharedNodeHandleStyle, right: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />{' '}
       <Handle
         type="source"
         position={Position.Left}
         id="leftSource"
-        style={{ ...sharedNodeHandleStyle, left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Left}
         id="leftTarget"
-        style={{ ...sharedNodeHandleStyle, left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
-      <NodeText data={data} shapeSettings={shapeSettings} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="149"
@@ -233,6 +228,7 @@ export function ProxyAdmin({ data }: { data: NodeDisplayData }) {
           </defs>
         </svg>
       </Link>
+      <NodeText data={data} />
     </Box>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Stake.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Stake.tsx
@@ -1,16 +1,11 @@
-import { Box, Link, useBreakpointValue } from '@concave/ui'
+import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
 import { Handle, Position } from 'react-flow-renderer'
 import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
-import { NodeDisplayData, ShapeLabelSettingsType } from '../../types'
+import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
 
 export function Stake({ data }: { data: NodeDisplayData }) {
-  const isMobile = useBreakpointValue({ base: true, md: false })
-  const shapeSettings: ShapeLabelSettingsType = {
-    labelBottom: '-55px',
-  }
-
   const explorerURL = getExplorerURL(data)
 
   return (
@@ -19,51 +14,50 @@ export function Stake({ data }: { data: NodeDisplayData }) {
         type="target"
         position={Position.Top}
         id="topTarget"
-        style={{ ...sharedNodeHandleStyle, top: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Top}
         id="topSource"
-        style={{ ...sharedNodeHandleStyle, top: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Bottom}
         id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle, bottom: isMobile ? '-110px' : '-66px' }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Bottom}
         id="bottomSource"
-        style={{ ...sharedNodeHandleStyle, bottom: isMobile ? '-110px' : '-66px' }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Right}
         id="rightSource"
-        style={{ ...sharedNodeHandleStyle, right: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Right}
         id="rightTarget"
-        style={{ ...sharedNodeHandleStyle, right: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Left}
         id="leftSource"
-        style={{ ...sharedNodeHandleStyle, left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Left}
         id="leftTarget"
-        style={{ ...sharedNodeHandleStyle, left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
-      <NodeText data={data} shapeSettings={shapeSettings} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="89"
@@ -180,6 +174,7 @@ export function Stake({ data }: { data: NodeDisplayData }) {
           </defs>
         </svg>
       </Link>
+      <NodeText data={data} />
     </Box>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Stake.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Stake.tsx
@@ -1,67 +1,21 @@
 import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
-import { Handle, Position } from 'react-flow-renderer'
-import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
+import { sharedNodeContainerStyle } from '../../styles'
 import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
+import { Handles } from './Handles'
 
 export function Stake({ data }: { data: NodeDisplayData }) {
   const explorerURL = getExplorerURL(data)
 
   return (
-    <Box sx={{ ...sharedNodeContainerStyle }}>
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="topTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="topSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Bottom}
-        id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottomSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="rightSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Right}
-        id="rightTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="leftSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="leftTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
+    <Box sx={{ ...sharedNodeContainerStyle }} maxW={'99px'}>
+      <Handles top={60} />
+
       <Link href={explorerURL} target="_blank">
         <svg
           width="89"
-          height="122"
+          height="120"
           viewBox="0 0 89 122"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Token.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Token.tsx
@@ -2,67 +2,62 @@ import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
 import { Handle, Position } from 'react-flow-renderer'
 import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
-import { NodeDisplayData, ShapeLabelSettingsType } from '../../types'
+import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
 
 export function Token({ data }: { data: NodeDisplayData }) {
-  const shapeSettings: ShapeLabelSettingsType = {
-    labelBottom: '-55px',
-  }
-
   const explorerURL = getExplorerURL(data)
 
   return (
-    <Box sx={{ ...sharedNodeContainerStyle }}>
+    <Box sx={{ ...sharedNodeContainerStyle, minH: '180px', height: '180px' }}>
       <Handle
         type="target"
         position={Position.Top}
         id="topTarget"
-        style={{ ...sharedNodeHandleStyle, top: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Top}
         id="topSource"
-        style={{ ...sharedNodeHandleStyle, top: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Bottom}
         id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle, bottom: -66 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Bottom}
         id="bottomSource"
-        style={{ ...sharedNodeHandleStyle, bottom: -66 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Right}
         id="rightSource"
-        style={{ ...sharedNodeHandleStyle, right: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Right}
         id="rightTarget"
-        style={{ ...sharedNodeHandleStyle, right: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Left}
         id="leftSource"
-        style={{ ...sharedNodeHandleStyle, left: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Left}
         id="leftTarget"
-        style={{ ...sharedNodeHandleStyle, left: -16 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
-      <NodeText data={data} shapeSettings={shapeSettings} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="122"
@@ -99,6 +94,7 @@ export function Token({ data }: { data: NodeDisplayData }) {
           </defs>
         </svg>
       </Link>
+      <NodeText data={data} />
     </Box>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Token.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/Token.tsx
@@ -1,63 +1,16 @@
 import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
-import { Handle, Position } from 'react-flow-renderer'
-import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
+import { sharedNodeContainerStyle } from '../../styles'
 import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
+import { Handles } from './Handles'
 
 export function Token({ data }: { data: NodeDisplayData }) {
   const explorerURL = getExplorerURL(data)
 
   return (
-    <Box sx={{ ...sharedNodeContainerStyle, minH: '180px', height: '180px' }}>
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="topTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="topSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Bottom}
-        id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottomSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="rightSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Right}
-        id="rightTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="leftSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="leftTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
+    <Box sx={{ ...sharedNodeContainerStyle, minH: '160px', height: '160px' }}>
+      <Handles top={50} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="122"

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/User.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/User.tsx
@@ -1,65 +1,60 @@
 import { Box } from '@concave/ui'
 import { Handle, Position } from 'react-flow-renderer'
 import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
-import { NodeDisplayData, ShapeLabelSettingsType } from '../../types'
+import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
 
 export function User({ data }: { data: NodeDisplayData }) {
-  const shapeSettings: ShapeLabelSettingsType = {
-    labelBottom: '-45px',
-  }
-
   return (
     <Box sx={{ ...sharedNodeContainerStyle }}>
       <Handle
         type="target"
         position={Position.Top}
         id="topTarget"
-        style={{ ...sharedNodeHandleStyle, top: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Top}
         id="topSource"
-        style={{ ...sharedNodeHandleStyle, top: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Bottom}
         id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle, bottom: -45 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Bottom}
         id="bottomSource"
-        style={{ ...sharedNodeHandleStyle, bottom: -45 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Right}
         id="rightSource"
-        style={{ ...sharedNodeHandleStyle, right: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Right}
         id="rightTarget"
-        style={{ ...sharedNodeHandleStyle, right: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Left}
         id="leftSource"
-        style={{ ...sharedNodeHandleStyle, left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Left}
         id="leftTarget"
-        style={{ ...sharedNodeHandleStyle, left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
-      <NodeText data={data} shapeSettings={shapeSettings} />
       <svg
         width="89"
         height="127"
@@ -112,6 +107,7 @@ export function User({ data }: { data: NodeDisplayData }) {
           </radialGradient>
         </defs>
       </svg>
+      <NodeText data={data} />
     </Box>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/User.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/User.tsx
@@ -1,60 +1,13 @@
 import { Box } from '@concave/ui'
-import { Handle, Position } from 'react-flow-renderer'
-import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
+import { sharedNodeContainerStyle } from '../../styles'
 import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
+import { Handles } from './Handles'
 
 export function User({ data }: { data: NodeDisplayData }) {
   return (
     <Box sx={{ ...sharedNodeContainerStyle }}>
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="topTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="topSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Bottom}
-        id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottomSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="rightSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Right}
-        id="rightTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="leftSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="leftTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
+      <Handles top={62}></Handles>
       <svg
         width="89"
         height="127"

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/ValueShuttle.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/ValueShuttle.tsx
@@ -1,63 +1,16 @@
 import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
-import { Handle, Position } from 'react-flow-renderer'
-import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
+import { sharedNodeContainerStyle } from '../../styles'
 import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
+import { Handles } from './Handles'
 
 export function ValueShuttle({ data }: { data: NodeDisplayData }) {
   const explorerURL = getExplorerURL(data)
 
   return (
     <Box sx={{ ...sharedNodeContainerStyle }}>
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="topTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Top}
-        id="topSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Bottom}
-        id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="bottomSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="rightSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Right}
-        id="rightTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="leftSource"
-        style={{ ...sharedNodeHandleStyle }}
-      />
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="leftTarget"
-        style={{ ...sharedNodeHandleStyle }}
-      />
+      <Handles top={41} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="167"

--- a/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/ValueShuttle.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/CustomShapes/ValueShuttle.tsx
@@ -2,14 +2,10 @@ import { Box, Link } from '@concave/ui'
 import { getExplorerURL } from 'components/TransparencyDiagram/utils'
 import { Handle, Position } from 'react-flow-renderer'
 import { sharedNodeContainerStyle, sharedNodeHandleStyle } from '../../styles'
-import { NodeDisplayData, ShapeLabelSettingsType } from '../../types'
+import { NodeDisplayData } from '../../types'
 import { NodeText } from '../NodeText'
 
 export function ValueShuttle({ data }: { data: NodeDisplayData }) {
-  const shapeSettings: ShapeLabelSettingsType = {
-    labelBottom: '-55px',
-  }
-
   const explorerURL = getExplorerURL(data)
 
   return (
@@ -18,51 +14,50 @@ export function ValueShuttle({ data }: { data: NodeDisplayData }) {
         type="target"
         position={Position.Top}
         id="topTarget"
-        style={{ ...sharedNodeHandleStyle, top: -15, left: '50%' }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Top}
         id="topSource"
-        style={{ ...sharedNodeHandleStyle, top: -15, left: '50%' }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Bottom}
         id="bottomTarget"
-        style={{ ...sharedNodeHandleStyle, bottom: '-66px', left: '50%' }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Bottom}
         id="bottomSource"
-        style={{ ...sharedNodeHandleStyle, bottom: '-66px', left: '50%' }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Right}
         id="rightSource"
-        style={{ ...sharedNodeHandleStyle, top: '50%', right: -8 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Right}
         id="rightTarget"
-        style={{ ...sharedNodeHandleStyle, top: '50%', right: -8 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="source"
         position={Position.Left}
         id="leftSource"
-        style={{ ...sharedNodeHandleStyle, top: '50%', left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
       <Handle
         type="target"
         position={Position.Left}
         id="leftTarget"
-        style={{ ...sharedNodeHandleStyle, top: '50%', left: -15 }}
+        style={{ ...sharedNodeHandleStyle }}
       />
-      <NodeText data={data} shapeSettings={shapeSettings} />
       <Link href={explorerURL} target="_blank">
         <svg
           width="167"
@@ -179,6 +174,7 @@ export function ValueShuttle({ data }: { data: NodeDisplayData }) {
           </defs>
         </svg>
       </Link>
+      <NodeText data={data} />
     </Box>
   )
 }

--- a/apps/cave/components/TransparencyDiagram/nodes/NodeText.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/NodeText.tsx
@@ -1,14 +1,8 @@
 import { Box, Link, Text, useBreakpointValue } from '@concave/ui'
-import { NodeDisplayData, ShapeLabelSettingsType } from '../types'
+import { NodeDisplayData } from '../types'
 import { getExplorerURL, wrapText } from '../utils'
 
-export const NodeText = ({
-  data,
-  shapeSettings,
-}: {
-  data: NodeDisplayData
-  shapeSettings: ShapeLabelSettingsType
-}) => {
+export const NodeText = ({ data }: { data: NodeDisplayData }) => {
   const isMobile = useBreakpointValue({ base: true, md: false })
 
   let style: {
@@ -38,16 +32,7 @@ export const NodeText = ({
   const explorerURL: string | undefined = getExplorerURL(data)
 
   return (
-    <Box
-      sx={{
-        position: 'fixed',
-        left: shapeSettings.labelLeft,
-        bottom: shapeSettings.labelBottom,
-        width: 'max-content',
-        textAnchor: 'middle',
-        transform: style.textTransform,
-      }}
-    >
+    <Box mt={2}>
       {isMobile && data.address && typeof label !== 'string' ? (
         <Link href={explorerURL} target="_blank" lineHeight={style.lineHeight}>
           {label.map((textLine, i) => (

--- a/apps/cave/components/TransparencyDiagram/nodes/NodeText.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/NodeText.tsx
@@ -14,7 +14,7 @@ export const NodeText = ({ data }: { data: NodeDisplayData }) => {
   let label: string | string[]
 
   if (isMobile) {
-    label = wrapText(data.label, 12)
+    label = wrapText(data.label, 10)
     style = {
       labelFontSize: '2rem',
       lineHeight: '2.75rem',
@@ -43,11 +43,16 @@ export const NodeText = ({ data }: { data: NodeDisplayData }) => {
         </Link>
       ) : (
         <>
-          <Text color={'white'} fontSize={style.labelFontSize}>
+          <Text color={'white'} whiteSpace={'nowrap'} fontSize={style.labelFontSize}>
             {label}
           </Text>
           {data.address && (
-            <Text color={'white'} fontSize={style.linkFontSize} lineHeight={style.lineHeight}>
+            <Text
+              color={'white'}
+              fontSize={style.linkFontSize}
+              whiteSpace={'nowrap'}
+              lineHeight={style.lineHeight}
+            >
               <Link href={explorerURL} target="_blank">
                 View contract
               </Link>

--- a/apps/cave/components/TransparencyDiagram/nodes/nodes.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/nodes.tsx
@@ -228,23 +228,36 @@ export const generalNodes = [
   avaxSafe(375, 0),
 ]
 
+/**
+ * every node has 230 by default
+ * this chart has 6 lines, 6 x 230 = 1380
+ */
 export const generalNodesMobile = [
-  bbtCNV(540, -80),
-  aCNV(540, 110),
-  cnv(540, 300),
-  pCNV(540, 490),
-  lsdCNV(540, -260),
-  concaveTreasury(300, 390),
-  coopTreasury(150, 390),
-  policyMultisig(0, 390),
-  proxyAdmin(525, 650),
-  accrualBondsV1Proxy(250, 765),
-  accrualBondsV1Impl(0, 765),
-  stakingV1Proxy(375, 50),
-  stakingV1Impl(225, 50),
-  valueShuttle(0, 70),
-  bscSafe(28, -290),
-  avaxSafe(250, -290),
+  //sidebar
+  bbtCNV(580, 230),
+  aCNV(580, 460),
+  cnv(580, 690),
+  pCNV(580, 920),
+  lsdCNV(580, 0),
+
+  //line 1
+  bscSafe(28, 0 + 30),
+  avaxSafe(250, 0 + 30),
+
+  //line 2
+  stakingV1Proxy(375, 383 + 20),
+  stakingV1Impl(207, 383 + 20),
+  valueShuttle(0, 383 + 20),
+
+  //line 3
+  policyMultisig(0, 767 + 10),
+  concaveTreasury(300, 767 + 10),
+  coopTreasury(150, 767 + 10),
+
+  //line 4
+  accrualBondsV1Proxy(250, 1150),
+  accrualBondsV1Impl(0, 1150),
+  proxyAdmin(525, 1150),
 ]
 
 export const bondingNodes = [
@@ -261,14 +274,14 @@ export const bondingNodes = [
 
 export const bondingNodesMobile = [
   user(660, 0),
-  proxyAdmin(900, 0),
-  cnv(1200, 0),
+  proxyAdmin(850, 0),
+  cnv(1100, 0),
   coopTreasury(641, 1050),
   valueShuttle(620, 700),
   accrualBondsV1Proxy(600, 350),
-  concaveTreasury(1200, 350),
-  accrualBondsV1Impl(900, 700),
-  policyMultisig(1200, 700),
+  concaveTreasury(1100, 350),
+  accrualBondsV1Impl(840, 700),
+  policyMultisig(1100, 700),
 ]
 
 export const stakingNodes = [
@@ -285,14 +298,17 @@ export const stakingNodes = [
 ]
 
 export const stakingNodesMobile = [
-  lsdCNV(900, 20),
-  proxyAdmin(880, 410),
-  concaveTreasury(893, 800),
-  cnv(600, 1100),
-  user(600, 0),
-  valueShuttle(250, 20),
-  stakingV1Proxy(600, 400),
-  policyMultisig(583, 800),
-  stakingV1Impl(250, 400),
+  valueShuttle(250, 0),
+  user(530, 0),
+  lsdCNV(740, 25),
+
+  stakingV1Impl(260, 400),
+  stakingV1Proxy(504, 400),
+  proxyAdmin(690, 400),
+
   coopTreasury(250, 800),
+  policyMultisig(483, 800),
+  concaveTreasury(700, 800),
+
+  cnv(500, 1100),
 ]

--- a/apps/cave/components/TransparencyDiagram/nodes/nodes.tsx
+++ b/apps/cave/components/TransparencyDiagram/nodes/nodes.tsx
@@ -214,16 +214,16 @@ export const generalNodes = [
   aCNV(385, 600),
   cnv(650, 600),
   pCNV(385, 400),
-  lsdCNV(385, 1016),
+  lsdCNV(385, 1010),
   concaveTreasury(975, 480),
   coopTreasury(1225, 480),
   policyMultisig(1475, 480),
-  proxyAdmin(0, 485),
+  proxyAdmin(0, 500),
   accrualBondsV1Proxy(700, 0),
   accrualBondsV1Impl(1150, 0),
   stakingV1Proxy(760, 1000),
   stakingV1Impl(1150, 1000),
-  valueShuttle(1650, 1020),
+  valueShuttle(1650, 1019),
   bscSafe(100, 0),
   avaxSafe(375, 0),
 ]
@@ -241,46 +241,46 @@ export const generalNodesMobile = [
   lsdCNV(580, 0),
 
   //line 1
-  bscSafe(28, 0 + 30),
-  avaxSafe(250, 0 + 30),
+  bscSafe(28, 0),
+  avaxSafe(250, 0),
 
   //line 2
-  stakingV1Proxy(375, 383 + 20),
-  stakingV1Impl(207, 383 + 20),
-  valueShuttle(0, 383 + 20),
+  valueShuttle(0, 402 + 20),
+  stakingV1Proxy(365, 383 + 20),
+  stakingV1Impl(219, 383 + 20),
 
   //line 3
   policyMultisig(0, 767 + 10),
-  concaveTreasury(300, 767 + 10),
-  coopTreasury(150, 767 + 10),
+  coopTreasury(155, 767 + 10),
+  concaveTreasury(310, 767 + 10),
 
   //line 4
-  accrualBondsV1Proxy(250, 1150),
+  accrualBondsV1Proxy(280, 1150),
   accrualBondsV1Impl(0, 1150),
-  proxyAdmin(525, 1150),
+  proxyAdmin(565, 1160),
 ]
 
 export const bondingNodes = [
-  user(660, 0),
+  user(688, 0),
   proxyAdmin(900, 0),
   cnv(1200, 0),
   coopTreasury(0, 400),
   valueShuttle(300, 425),
   accrualBondsV1Proxy(600, 400),
   concaveTreasury(1200, 400),
-  accrualBondsV1Impl(600, 800),
+  accrualBondsV1Impl(607, 800),
   policyMultisig(1200, 800),
 ]
 
 export const bondingNodesMobile = [
   user(660, 0),
-  proxyAdmin(850, 0),
+  proxyAdmin(863, 0),
   cnv(1100, 0),
-  coopTreasury(641, 1050),
-  valueShuttle(620, 700),
-  accrualBondsV1Proxy(600, 350),
+  coopTreasury(645, 1000),
+  valueShuttle(620, 720),
+  accrualBondsV1Proxy(593, 358),
   concaveTreasury(1100, 350),
-  accrualBondsV1Impl(840, 700),
+  accrualBondsV1Impl(826, 705),
   policyMultisig(1100, 700),
 ]
 
@@ -298,17 +298,17 @@ export const stakingNodes = [
 ]
 
 export const stakingNodesMobile = [
-  valueShuttle(250, 0),
-  user(530, 0),
-  lsdCNV(740, 25),
+  valueShuttle(225, 50),
+  user(510, 29),
+  lsdCNV(722, 41),
 
   stakingV1Impl(260, 400),
   stakingV1Proxy(504, 400),
-  proxyAdmin(690, 400),
+  proxyAdmin(710, 410),
 
   coopTreasury(250, 800),
-  policyMultisig(483, 800),
-  concaveTreasury(700, 800),
+  policyMultisig(492, 800),
+  concaveTreasury(724, 800),
 
   cnv(500, 1100),
 ]

--- a/apps/cave/components/TransparencyDiagram/styles.js
+++ b/apps/cave/components/TransparencyDiagram/styles.js
@@ -13,6 +13,8 @@ export const sharedNodeContainerStyle = {
   justifyContent: 'center',
   alignItems: 'center',
   cursor: 'default',
+  minHeight: '230px',
+  // border: '1px solid white'
 }
 
 export const labelStyle = {

--- a/apps/cave/components/TransparencyDiagram/styles.js
+++ b/apps/cave/components/TransparencyDiagram/styles.js
@@ -13,7 +13,7 @@ export const sharedNodeContainerStyle = {
   justifyContent: 'center',
   alignItems: 'center',
   cursor: 'default',
-  minHeight: '230px',
+  // minHeight: '200px',
   // border: '1px solid white'
 }
 

--- a/apps/cave/components/TransparencyDiagram/types.ts
+++ b/apps/cave/components/TransparencyDiagram/types.ts
@@ -12,8 +12,3 @@ export type NodeDisplayData = {
   address?: string
   addressType?: AddressTypeEnum
 }
-
-export type ShapeLabelSettingsType = {
-  labelLeft?: string
-  labelBottom: string
-}


### PR DESCRIPTION
## Description

all of our react flow diagrams can't fit content on the right way (it is cutting labels of shapes),  and for this reason we was setting a padding, but it create a unnecessary whitespace around the flow 

<img width="331" alt="Screen Shot 2022-11-07 at 13 42 42" src="https://user-images.githubusercontent.com/5888609/200366078-4ea15481-5bc2-4599-89fd-4a0d06907656.png">

In this PR i fixed the problem of shapes and reorganized disposition inside every flow, and now we can apply fit content efficiently
<img width="331" alt="Screen Shot 2022-11-07 at 13 37 50" src="https://user-images.githubusercontent.com/5888609/200367161-2e40fcdd-f727-4c52-8c37-9125e3a7954f.png">

