### PR TITLE
add compactFormat to locked series

### DIFF
--- a/apps/cave/components/Transparency/Charts/LockedCNVSeriesChart.tsx
+++ b/apps/cave/components/Transparency/Charts/LockedCNVSeriesChart.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@concave/ui'
+import { Text, useBreakpointValue } from '@concave/ui'
 import {
   Area,
   AreaChart,
@@ -9,6 +9,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
+import { compactFormat } from 'utils/numberMask'
 import { ChartCard } from './ChartCard'
 import { ChartTooltip } from './ChartTooltip'
 import { CustomizedAxisTick } from './CustomizedAxisTick'
@@ -30,6 +31,7 @@ export const LockedCNVSeriesChart = () => {
     bottom: 50,
   }
 
+  const isMobile = useBreakpointValue({ base: true, xl: false })
   const lockedCNVSeries = useFetchData<LockedCNVSeriesData>('locked-series')
   const dataLoaded = !lockedCNVSeries.isLoading
   const data = lockedCNVSeries.data
@@ -76,7 +78,7 @@ export const LockedCNVSeriesChart = () => {
             <YAxis
               axisLine={{ stroke: CHART_COLORS.TextLow }}
               tickLine={{ stroke: CHART_COLORS.TextLow }}
-              tickFormatter={(v) => v.toLocaleString()}
+              tickFormatter={(v: number) => (isMobile ? compactFormat(v) : v.toLocaleString())}
               style={{ fill: CHART_COLORS.TextLow, fontSize: '0.8rem' }}
             >
               <Label

--- a/apps/cave/utils/numberMask.ts
+++ b/apps/cave/utils/numberMask.ts
@@ -28,3 +28,6 @@ export const numberMask = (number: Number, decimals?: number): string => {
   const decimalCount = decimals || 2
   return commify(numSplice(number, decimalCount))
 }
+
+export const compactFormat = (number: number) =>
+  Intl.NumberFormat('en', { notation: 'compact' }).format(number)


### PR DESCRIPTION
- adds `compactFormat(number: number)` to `numberMask`
- implements new `compactFormat` in locked series

old
![image](https://user-images.githubusercontent.com/96499579/213056081-18587a62-1ef2-4689-8458-248026d1acd5.png)

new
![image](https://user-images.githubusercontent.com/96499579/213056096-3eb231e9-a5f8-4b83-9052-e800c41ef948.png)