### PR TITLE
Layout of Transparency page

### DIFF
--- a/apps/cave/components/TransparencyDiagram/TransparencyDiagram.tsx
+++ b/apps/cave/components/TransparencyDiagram/TransparencyDiagram.tsx
@@ -68,7 +68,7 @@ export function TransparencyDiagram({ isMobile }: { isMobile: boolean }) {
         bg="bg.primary"
         shadow={'up'}
         minH={'500px'}
-        maxH={{ base: '90vh', md: '800px' }}
+        w={'full'}
         p={{ base: 4, sm: 5 }}
         gap={{ base: 2, sm: 5 }}
       >


### PR DESCRIPTION
## Description

Before:
<img width="967" alt="Screen Shot 2023-04-28 at 15 22 57" src="https://user-images.githubusercontent.com/5888609/235224546-0c168950-aa0f-49d3-a01e-a97dac5ca466.png">

Now:
<img width="967" alt="Screen Shot 2023-04-28 at 15 24 43" src="https://user-images.githubusercontent.com/5888609/235224943-92d9df0e-38a0-4ff3-bce2-9a4ad42f4922.png">
